### PR TITLE
Keep at least one commented pool server in template

### DIFF
--- a/ntp/templates/ntp.conf.erb
+++ b/ntp/templates/ntp.conf.erb
@@ -16,6 +16,9 @@ restrict -6 ::1
 
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
+# server 0.pool.ntp.org
+
+# We synchronise from the following
 <% scope.lookupvar('ntp::params::ntp_server').each do |ntp| %>server <%= ntp %>
 <% end %>
 


### PR DESCRIPTION
If a site uses non-pool NTP servers (they have their own infrastructure) then the
comments directly above the iterated list of servers makes no sense.

Better to leave reference to the pool servers and explicitly state which servers
we're using.
