### PR TITLE
use $osfamily to be more portable

### DIFF
--- a/cron/manifests/init.pp
+++ b/cron/manifests/init.pp
@@ -1,17 +1,13 @@
 class cron {
 
-    case $operatingsystem {
-        centos: {
+    case $::osfamily {
+        'Redhat': {
             include cron::base
             include cron::crontabs
         }
-        redhat: {
+        'Debian': {
             include cron::base
-            include cron::crontabs
         }
-
-        debian: { include cron::base }
-        ubuntu: { include cron::base }
         freebsd: { }
     }
 


### PR DESCRIPTION
1. Use $::osfamily to cover entire "Redhat" family (SL, Fedora etc) and Debian/Ubuntu to avoid duplication and be more portable ('Redhat' family convers also Scientific Linux, for instance)
2. Use absolute variable paths since relative ones will be deprecated in Puppet 2.8

ref for $osfamily: https://github.com/puppetlabs/facter/blob/master/lib/facter/osfamily.rb
