### PR TITLE
Timezone Set Timezone and HW UTC

### DIFF
--- a/timezone/manifests/init.pp
+++ b/timezone/manifests/init.pp
@@ -1,6 +1,6 @@
 # Defaults to setting up the timezone to match what it's already set to. If you
 # set the timezone variable for the class it will use that timezone instead.
-class timezone(timezone=$timezone) {
+class timezone(timezone=$timezone, hw_utc=false) {
 
      file {
         "timezone":

--- a/timezone/templates/timezone-CentOS
+++ b/timezone/templates/timezone-CentOS
@@ -1,5 +1,5 @@
 # File managed by Puppet
 
 ZONE="<%= timezone %>"
-UTC=false
+UTC=<%= hw_utc %>
 ARC=false

--- a/timezone/templates/timezone-RedHat
+++ b/timezone/templates/timezone-RedHat
@@ -1,5 +1,5 @@
 # File managed by Puppet
 
 ZONE="<%= timezone %>"
-UTC=false
+UTC=<%= hw_utc %>
 ARC=false

--- a/timezone/templates/timezone-Scientific
+++ b/timezone/templates/timezone-Scientific
@@ -1,5 +1,5 @@
 # File managed by Puppet
 
 ZONE="<%= timezone %>"
-UTC=false
+UTC=<%= hw_utc %>
 ARC=false

--- a/timezone/templates/timezone-SuSE
+++ b/timezone/templates/timezone-SuSE
@@ -8,7 +8,11 @@
 # Set to "-u" if your system clock is set to UTC, and to "--localtime"
 # if your clock runs that way.
 #
+<% if hw_utc == true -%>
+HWCLOCK="-u"
+<% else -%>
 HWCLOCK="--localtime"
+<% end -%>
 
 ## Type:		yesno
 ## Default:		yes


### PR DESCRIPTION
I know you're in the process of re-writing various modules into the new format, but I needed to patch the timezone module for our use anyhow, and I thought you might want to merge the patch into your master.

These two commits add a couple of parameters to the timezone class so that it can set the timezone to something other than what facter returns, and also so we can set the Hardware clock to UTC. (though that's only for Redhat based and SuSE; I don't know how to set that on Debian/Ubuntu) If neither parameter is set it will do the same thing as it does now.
