### PR TITLE
Fixed syntax errors in timezone module

### DIFF
--- a/timezone/manifests/init.pp
+++ b/timezone/manifests/init.pp
@@ -1,6 +1,9 @@
 # Defaults to setting up the timezone to match what it's already set to. If you
 # set the timezone variable for the class it will use that timezone instead.
-class timezone(timezone=$timezone, hw_utc=false) {
+class timezone(
+  $timezone = params_lookup('timezone', 'global'),
+  $hw_utc = false
+  ) {
 
      file {
         "timezone":


### PR DESCRIPTION
The timezone module contained some syntax errors. I think I herewith fixed them while maintaining backwards compatibility.
