### PR TITLE
Some enhancements to ci and scripting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,27 @@ stages:
   - postcheck
 
 
-# Development branch
+after_script:
+  - "bin/gitlab_after.sh"
+
+# Version Deploy check for every branch with environment creation
+# It will try by default 6 times with 10 second between each try
+# so that Puppet has time to get the new version of the repository
+verify_code_deploy:
+  stage: version_check
+  script:
+    - "bin/codemanager_check_deploy.sh ${CI_BUILD_REF_NAME}"
+  tags:
+    - deploy_puppet
+  when: on_success
+  allow_failure: true
+  environment:
+    name: ${CI_BUILD_REF_NAME}
+    url: https://puppetmaster.domain.name/
+
+# Run Syntax Checks on Feature/Personal Branch
+# and Development branch:
+# All branches exluded production and testing
 syntax:
   stage: checks
   before_script:
@@ -28,15 +48,17 @@ syntax:
     untracked: true
     paths:
     - modules/
-    - vagrant/environments/ci/.vagrant/
   tags:
     - test_puppet
+  except:
+    - testing
+    - production
   only:
-    - development
-  environment:
-    name: development
-    url: https://lab.psick.io
+    - branches
 
+# Run Syntax Checks on Feature/Personal Branch
+# and Development branch:
+# All branches exluded production and testing
 lint:
   stage: checks
   before_script:
@@ -46,11 +68,13 @@ lint:
     untracked: true
     paths:
     - modules/
-    - vagrant/environments/ci/.vagrant/
   tags:
     - test_puppet
+  except:
+    - testing
+    - production
   only:
-    - development
+    - branches
   allow_failure: true
 
 rake_site:
@@ -115,11 +139,58 @@ catalog_preview:
     - development
   allow_failure: true
 
-vagrant_setup:
+# Can be duplicated to use different images (using different --image)
+# or with custom facts --facts. Check docker_run.sh for all the options.
+docker_test:
   stage: integration
   before_script:
     - "bin/gitlab_before.sh"
-  script: "bin/vagrant_node_test.sh oracle ci setup"
+  script:
+    - "bin/docker_run.sh --image centos-7"
+  cache:
+    untracked: true
+    paths:
+    - modules/
+  allow_failure: true
+  tags:
+    - test_puppet
+  only:
+    - development
+
+# Destroy a vagrant machine completely.
+vagrant_destroy:
+  stage: integration
+  before_script:
+    - "bin/gitlab_before.sh"
+  script:
+    - "bin/vagrant_node_test.sh centos7ci.domain.com ci destroy"
+  cache:
+    untracked: true
+    paths:
+      #    - vagrant/environments/gitlabci/.vagrant/
+    - modules/
+    - tests/
+  allow_failure: true
+  tags:
+    - test_puppet
+  only:
+    - development
+  when: manual
+
+
+# Do Vagrant run. Start the machine, run the tests, halt the machine.
+# This will use a .vagrant dir under $HOME of the users so that 
+# it will not be deleted accidentally  by gitlab-runner
+vagrant_checks:
+  stage: integration
+  before_script:
+    - "bin/gitlab_before.sh"
+  script:
+    - "bin/vagrant_node_test.sh centos7ci.domain.com ci setup"
+    - "bin/vagrant_node_test.sh centos7ci.domain.com ci drift"
+  after_script:
+    - "bin/gitlab_after.sh"
+    - "bin/vagrant_node_test.sh centos7ci.domain.com ci halt"
   cache:
     untracked: true
     paths:
@@ -130,21 +201,7 @@ vagrant_setup:
     - test_puppet
   only:
     - development
-
-vagrant_drift:
-  stage: integration
-  before_script:
-    - "bin/gitlab_before.sh"
-  script: "bin/vagrant_node_test.sh oracle ci drift"
-  cache:
-    untracked: true
-    paths:
-    - modules/
-    - tests/
-  tags:
-    - test_puppet
-  only:
-    - development
+  when: manual
 
 tp_test:
   stage: integration
@@ -162,30 +219,41 @@ tp_test:
     - development
   allow_failure: true
 
-verify_code_deploy_development:
-  stage: version_check
-  script:
-    - "bin/codemanager_check_deploy.sh development"
-  tags:
-    - deploy_puppet
-  when: on_success
-  only:
-    - development
-  allow_failure: true
-
-deploy_to_testing:
-  stage: promote
+# Development to testing merge request creation
+merge_request_testing:
+  stage: merge_request
   script:
     - "bin/gitlab_create_merge_request.rb development testing"
+  tags:
+    - deploy_puppet
+  only:
+    - development
+
+# Automatic Accept merge request from Development to testing 
+merge_accept_testing:
+  stage: promote
+  script:
     - "bin/gitlab_accept_merge_request.rb development testing"
   tags:
     - deploy_puppet
-  when: on_success
   only:
     - development
-  environment:
-    name: testing
-    url: https://staging.example.com
+
+# Remotely Run a job on rundeck server via the Rundeck cli.
+# This will need a rundeck cli, a Rundeck Server and a 
+# job on rundeck server that will the puppet agent
+rundeck_puppet_on_testing:
+  stage: live_runs
+  before_script:
+    - "bin/rundeck_job_run.sh testing"
+  script:
+    - "bin/puppetdb_env_query.sh testing"
+  tags:
+    - deploy_puppet
+  when: on_success
+  only:
+    - testing
+  allow_failure: true
 
 # On testing branch
 run_puppet_on_testing:
@@ -201,17 +269,9 @@ run_puppet_on_testing:
     - testing
   allow_failure: true
 
-verify_code_deploy_testing:
-  stage: version_check
-  script:
-    - "bin/codemanager_check_deploy.sh testing"
-  tags:
-    - deploy_puppet
-  when: on_success
-  only:
-    - testing
-  allow_failure: true # TOREMOVE when fixed
-
+# Allow Merge Request to fail as it can happen that there's
+# already a merge request from testing to production ready to
+# be merged
 merge_request_production:
   stage: merge_request
   script:
@@ -221,6 +281,7 @@ merge_request_production:
     - deploy_puppet
   only:
     - testing
+  allow_failure: true
 
 merge_accept_production:
   stage: promote
@@ -234,11 +295,13 @@ merge_accept_production:
   environment:
     name: production
 
-# Production
-canary_run_on_production:
+# Remotely Run a job on rundeck server via the Rundeck cli.
+# This will need a rundeck cli, a Rundeck Server and a 
+# job on rundeck server that will the puppet agent
+rundeck_run_on_production:
   stage: live_runs
   before_script:
-    - "bin/puppet_job_run.sh production"
+    - "bin/rundeck_job_run.sh production"
   script:
     - "bin/puppetdb_env_query.sh production"
   tags:
@@ -248,10 +311,14 @@ canary_run_on_production:
     - production
   allow_failure: true # TOREMOVE when fixed
 
-verify_code_deploy_production:
-  stage: version_check
+
+# Production
+canary_run_on_production:
+  stage: live_runs
+  before_script:
+    - "bin/puppet_job_run.sh production"
   script:
-    - "bin/codemanager_check_deploy.sh production"
+    - "bin/puppetdb_env_query.sh production"
   tags:
     - deploy_puppet
   when: on_success

--- a/bin/codemanager_check_deploy.sh
+++ b/bin/codemanager_check_deploy.sh
@@ -3,22 +3,31 @@ repo_dir="$(dirname $0)/.."
 . "${repo_dir}/bin/functions"
 
 env=$1
-
-echo_title "Deployment status on ${env}"
+maxrun=${2:-6}
+sleeptime=${3:-10}
+numrun=1
+exitcode=1
+echo_title "Display of /etc/puppetlabs/code/environments/$env/.r10k-deploy.json"
 sudo cat /etc/puppetlabs/code/environments/$env/.r10k-deploy.json
+echo_title "Deployment status on ${env} - doing maximum ${maxrun} try every ${sleeptime} sec."
+while [ $numrun -le $maxrun ]; 
+do
+	echo_title "Running check ${numrun}/${maxrun}"
+	deployed_commit=$(sudo /usr/bin/cat /etc/puppetlabs/code/environments/$env/.r10k-deploy.json | grep signature | awk '{ print $2}' | sed -e 's/"//g'  | sed -e 's/,//')
+	local_commit=$(git rev-parse HEAD)
+	echo_title "Deployed commit on Puppet Server: ${deployed_commit}"
+	git show --no-abbrev-commit -s ${deployed_commit}
+	echo_title "Latest commit on local runner repo: ${local_commit}"
+	git show --no-abbrev-commit -s ${local_commit}
 
-deployed_commit=$(sudo /usr/bin/cat /etc/puppetlabs/code/environments/$env/.r10k-deploy.json | grep signature | awk '{ print $2}' | sed -e 's/"//g'  | sed -e 's/,//')
-echo_title "Deployed commit on Puppet Server: ${deployed_commit}"
-git show --no-abbrev-commit -s ${deployed_commit}
-
-local_commit=$(git rev-parse HEAD)
-echo_title "Latest commit on local runner repo: ${local_commit}"
-git show --no-abbrev-commit -s ${local_commit}
-
-if [[ "${deployed_commit}" == "${local_commit}" ]]; then
-  echo_success "Code correctly deployed to Puppet Server"
-  exit 0 
-else
-  echo_failure "Code not correctly deployed to Puppet Server !!!"
-  exit 1 
-fi
+	echo_title "----------------------------------------------------------------------------------"
+	if [[ "${deployed_commit}" == "${local_commit}" ]]; then
+  		echo_success "Code correctly deployed to Puppet Server"
+		exitcode=0
+		exit 0
+	fi
+	sleep $sleeptime
+	(( numrun ++ ))
+done
+echo_failure "Code not correctly deployed to Puppet Server !!!"
+exit 1

--- a/bin/config/defaults
+++ b/bin/config/defaults
@@ -1,0 +1,13 @@
+vagrant_env="prod"
+vagrant_dc="docker"
+vagrant_zone="testzone"
+vagrant_app="puppet"
+vagrant_role="test"
+vagrant_host_env='ostest'
+
+docker_env="prod"
+docker_dc="docker"
+docker_zone="testzone"
+docker_app="puppet"
+docker_role="test"
+

--- a/bin/config/proxysetup
+++ b/bin/config/proxysetup
@@ -1,0 +1,4 @@
+#!/bin/sh
+#export http_proxy="http://proxy.domain.com:80"
+#export https_proxy="http://proxy.domain.com:80"
+#export no_proxy="domain.com,127.0.0.1,localhost"

--- a/bin/config/r10k.yaml
+++ b/bin/config/r10k.yaml
@@ -1,0 +1,3 @@
+---
+#you can put proxy or local definition here to be used instead of the r10k on puppet server
+#proxy: http://proxy.domain.com:80

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+repo_dir=$(git rev-parse --show-toplevel)
+. "${repo_dir}/bin/functions"
+. "${repo_dir}/bin/config/defaults"
+
+registry="myregistry.domain.name/puppet/"
+image="centos-7"
+version="latest"
+
+env=$docker_env
+datacenter=$docker_dc
+zone=$docker_zone
+application=$docker_app
+role=$docker_role
+runcommand="bash -c /etc/puppetlabs/code/environments/production/bin/papply.sh --detailed-exitcodes"
+custom=""
+options="--sysctl net.ipv6.conf.all.disable_ipv6=1"
+while [ $# -gt 0 ]; do
+  CMD=$1
+  shift 
+  if [ "${1}" != "" ] && [ "${1:0:2}" != "--" ]; then
+  	PARAM="$1"
+	  shift
+  else 
+	  PARAM=""
+  fi
+  case "$CMD" in 
+    --tags)
+      runcommand="${runcommand} --tags ${PARAM}"
+    ;;
+    --image)
+      image=${PARAM:-$image}
+    ;;
+    --version)
+      version=${PARAM:-$version}
+    ;;
+    --shell)
+      runcommand=${PARAM:-bash}
+      options="$options -it"
+    ;;
+    --role)
+      role=$PARAM
+    ;;
+    --zone)
+      zone=$PARAM
+    ;;
+    --env)
+      env=$PARAM
+    ;;
+    --datacenter)
+      datacenter=$PARAM
+    ;;
+    --application)
+      application=$PARAM
+    ;;
+    --fact)
+      custom="$custom -e FACTER_${PARAM}"
+    ;;
+    *)
+	    echo "Invalid paramete $CMD"
+	    exit 1
+    ;;
+  esac
+done
+
+params="-e FACTER_pp_environment=${env} -e FACTER_pp_role=${role} -e FACTER_pp_datacenter=${datacenter} -e FACTER_pp_application=${application} -e FACTER_pp_zone=${zone} $custom"
+name="${image}_${version}-${role}-$(date +'%H%M%S')" 
+container="${registry}${image}:${version}" 
+PATH=$PATH:/opt/puppetlabs/bin
+echo_title "## Running $runcommand on image ${image}:${version} from ${repo_dir}"
+echo_subtitle "Defined facts: $params"
+docker pull "${registry}${image}:${version}"
+docker run $options -v "${repo_dir}:/etc/puppetlabs/code/environments/production"  --name="${name}" $params "${container}" $runcommand
+exitstatus=$? 
+docker rm -f "${name}"
+
+if [ "x${exitstatus}" == "x0" ] || [ "x${exitstatus}" == "x2" ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/bin/gitlab_accept_merge_request.rb
+++ b/bin/gitlab_accept_merge_request.rb
@@ -8,9 +8,12 @@ File.foreach GITLAB_CONFIG do |line|
   config.store(k,v)
 end
 last_commit=`git log -1 --oneline`
-source_branch = ARGV[0] ? ARGV[0] : 'none'
-destination_branch = ARGV[1] ? ARGV[1] : 'master'
+#last_commit="-numero ultima commit-"
+source_branch = ARGV[0] ? ARGV[0] : 'development'
+destination_branch = ARGV[1] ? ARGV[1] : 'testing'
+mr_text = "MR: #{last_commit} from #{source_branch} to #{destination_branch}"
 mr_title = ARGV[2] ? ARGV[2] : "Merged: #{last_commit} from #{source_branch} to #{destination_branch}"
+
 project_id = config['GITLAB_API_PROJECT_ID']
 endpoint = config['GITLAB_API_ENDPOINT']
 private_token = config['GITLAB_API_PRIVATE_TOKEN']
@@ -19,7 +22,26 @@ httparty = config['GITLAB_API_HTTPARTY_OPTIONS'].gsub("'",'')
 Gitlab.endpoint = endpoint
 Gitlab.private_token = private_token
 Gitlab.httparty = eval(httparty)
-merge_requests = Gitlab.merge_requests(project_id, { page: 1 })
-mr_id = merge_requests.first.to_h['id']
-Gitlab.accept_merge_request(project_id,mr_id, { merge_commit_message: "#{mr_title}" })
+
+merge_requests = Gitlab.merge_requests(project_id, {page:1})
+merge_requests.has_next_page?
+merge_requests.next_page
+merge_requests.auto_paginate do |merge_request|
+  req=merge_request.to_h
+  if req["state"] == "opened"
+    mr_id=req["id"]
+    sb=req["source_branch"]
+    db=req["target_branch"]
+    if source_branch == sb and destination_branch == db
+      print "Merging id #{mr_id}: #{mr_text}\n"
+      Gitlab.accept_merge_request(project_id,mr_id, { merge_commit_message: "#{mr_title}" })
+      exit 0
+    end
+  end
+end
+
+merge_requests.auto_paginate
+
+print "Error: Merge Request NOT Found: #{mr_text}\n"
+exit 1
 

--- a/bin/gitlab_after.sh
+++ b/bin/gitlab_after.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+repo_dir="$(dirname $0)/.."
+script_dir="$(dirname $0)"
+
+echo "Cleanup keys"
+rm -f ${repo_dir}/keys/*
+echo

--- a/bin/gitlab_before.sh
+++ b/bin/gitlab_before.sh
@@ -4,8 +4,20 @@ script_dir="$(dirname $0)"
 # repo_dir=$(git rev-parse --show-toplevel)
 . "${script_dir}/functions"
 
+# r10k config file 
+configfile=${1:-bin/config/r10k.yaml}
+# Location of keys to copy into the local repository (removed from gilab_after.sh
+eyamlkeyloc=${1:-/etc/eyaml/keys}
+
+echo "Setup keys"
+mkdir -p ${repo_dir}/keys
+cp -f ${eyamlkeyloc}/* ${repo_dir}/keys/
+
+if [ -f "$configfile" ]; then
+	config="-c ${configfile}"
+fi
 echo 
 cd $repo_dir
 echo_title "Installing external modules via r10k"
-r10k puppetfile install -v
+r10k puppetfile install -v ${config}
 echo

--- a/bin/gitlab_catalog_preview.sh
+++ b/bin/gitlab_catalog_preview.sh
@@ -1,47 +1,50 @@
 #!/usr/bin/env bash
 
 test -f /etc/gitlab-ci.conf && . /etc/gitlab-ci.conf
-default_nodes=$catalag_preview_default_nodes
-always_nodes=$catalag_preview_always_nodes
+default_nodes=$catalog_preview_default_nodes
+always_nodes=$catalog_preview_always_nodes
 
 # Default number of commits to check for changed files
 diff_commits_number=1
-default_branch='production'
-env=$1
+global_exit=0
 nodes=0
+
+env=$1
 
 if [[ "x$env" != "x" ]]; then
   git checkout $env
+  git pull
 fi
-diff_commits_number=$(git log origin/$default_branch..$env --pretty=oneline | wc -l)
+diff_commits_number=$(git log origin/production..$env --pretty=oneline | wc -l)
 echo "Checking for files in the last $diff_commits_number commits"
-for changedfile in $(git diff origin/$default_branch..$env --name-only); do
+for changedfile in $(git diff origin/production..$env --name-only); do
   node=''
-  if [[ $(echo "$changedfile" | grep -q 'hieradata/nodes'; echo $?) -eq 0 ]]; then
-    node=$(echo $changedfile | sed -e "s/^hieradata\/nodes\///" -e "s/\.yaml//")
+  if [[ $(echo "$changedfile" | grep -q 'data/nodes'; echo $?) -eq 0 ]]; then
+    node=$(echo $changedfile | sed -e "s/^data\/nodes\///" -e "s/\.yaml//")
   fi
-#  if [[ $(echo "$changedfile" | grep -q 'hieradata/role'; echo $?) -eq 0 ]]; then
-#    role=$(echo $changedfile | sed -e "s/^hieradata\/role\///" -e "s/\.yaml//")
-#  fi
 
   if [[ "x$node" != "x" ]]; then
-    nodes=$nodes+1
     echo
     echo "Puppet preview diff on ${node} - Check based on commits"
-    sudo /opt/puppetlabs/bin/puppet preview --baseline_environment $default_branch --preview_environment $env $node
-  fi
+    sudo /opt/puppetlabs/bin/puppet preview --baseline_environment production --preview_environment $env $node
+    global_exit=$(($global_exit + $?))
+    nodes=$nodes+1
+  fi 
 done
 
 if [[ $nodes == 0 ]]; then
-  for node in $default_nodes; do
-    echo
-    echo "Catalog preview on ${node} - Default check"
-    sudo /opt/puppetlabs/bin/puppet preview --baseline_environment $default_branch --preview_environment $env $node
-  done
+    for node in ${default_nodes//,/ }; do
+      echo
+      echo "Catalog preview on ${node} - Default check"
+      sudo /opt/puppetlabs/bin/puppet preview --baseline_environment production --preview_environment $env $node
+      global_exit=$(($global_exit + $?))
+    done
 fi
 
-for node in $always_nodes; do
+for node in ${always_nodes//,/ }; do
   echo
   echo "Catalog preview on ${node} - Check always done"
-  sudo /opt/puppetlabs/bin/puppet preview --baseline_environment $default_branch --preview_environment $env $node
+  sudo /opt/puppetlabs/bin/puppet preview --baseline_environment production --preview_environment $env $node
+  global_exit=$(($global_exit + $?))
 done
+exit $global_exit

--- a/bin/gitlab_create_merge_request.rb
+++ b/bin/gitlab_create_merge_request.rb
@@ -8,18 +8,81 @@ File.foreach GITLAB_CONFIG do |line|
   config.store(k,v)
 end
 last_commit=`git log -1 --oneline`
-source_branch = ARGV[0] ? ARGV[0] : 'testing'
-destination_branch = ARGV[1] ? ARGV[1] : 'master'
-mr_title = ARGV[2] ? ARGV[2] : "MR:  #{last_commit} to #{destination_branch}"
+#last_commit="-numero ultima commit-"
+source_branch = ARGV[0] ? ARGV[0] : 'development'
+destination_branch = ARGV[1] ? ARGV[1] : 'testing'
+mr_title = ARGV[2] ? ARGV[2] : "MR:  #{last_commit} #{source_branch} to #{destination_branch}"
+
 project_id = config['GITLAB_API_PROJECT_ID']
 endpoint = config['GITLAB_API_ENDPOINT']
 private_token = config['GITLAB_API_PRIVATE_TOKEN']
 httparty = config['GITLAB_API_HTTPARTY_OPTIONS'].gsub("'",'')
 
+gitlab_user = config['GITLAB_USER']
+gitlab_milestone = config['GITLAB_MILESTONE']
+gitlab_labels = config['GITLAB_LABELS']
+autoadd_target = config['GITLAB_TARGET_LABEL']
+autoadd_source = config['GITLAB_SOURCE_LABEL']
+default_target = config['GITLAB_DEFAULT_TARGET_LABEL']
+default_source = config['GITLAB_DEFAULT_SOURCE_LABEL']
+
+if autoadd_target.to_s == "true"
+  gitlab_labels=gitlab_labels.to_s+default_target.to_s+destination_branch
+end
+
+if autoadd_source.to_s == "true"
+  gitlab_labels=gitlab_labels.to_s+default_source.to_s+source_branch
+end
+gitlab_labels=gitlab_labels.to_s.split(",").compact.reject(&:empty?).join(",")
+
 Gitlab.endpoint = endpoint
 Gitlab.private_token = private_token
 Gitlab.httparty = eval(httparty)
 
-Gitlab.create_merge_request(project_id,"#{mr_title}",options={ source_branch: source_branch, target_branch: destination_branch} )
-#Gitlab.create_merge_request(project_id,"#{mr_title}",options={ source_branch: source_branch, target_branch: destination_branch, merge_when_build_succeeds: true })
+assignee_id=""
+user_list=Gitlab.team_members(project_id, {page:1})
+user_list.has_next_page?
+user_list.next_page
+user_list.auto_paginate do |user|
+  u=user.to_h
+  if u["name"] == gitlab_user or u["username"] == gitlab_user
+     assignee_id= u["id"]
+  end
+end
+user_list.auto_paginate
+
+milestone_id=""
+milestone_list=Gitlab.milestones(project_id, {page:1})
+milestone_list.has_next_page?
+milestone_list.next_page
+milestone_list.auto_paginate do |milestone|
+  m=milestone.to_h
+  if m["title"] == gitlab_milestone
+     milestone_id= m["id"]
+  end
+end
+milestone_list.auto_paginate
+
+merge_requests = Gitlab.merge_requests(project_id, {page:1})
+merge_requests.has_next_page?
+merge_requests.next_page
+merge_requests.auto_paginate do |merge_request|
+  req=merge_request.to_h
+  if req["state"] == "opened"
+    id=req["id"]
+    sb=req["source_branch"]
+    db=req["target_branch"]
+    if source_branch == sb and destination_branch == db
+      print "#{mr_title}: already exist with ID Number #{id}.\n"
+      print "You only need to merge it.\n"
+      exit 1
+    end
+  end
+end
+merge_requests.auto_paginate
+
+print "Creating #{mr_title}\n Assignee: Name=#{gitlab_user} - Id=#{assignee_id}\n Milestone: Title=#{gitlab_milestone} - Id=#{milestone_id}\n Labels: #{gitlab_labels}\n\n"
+
+Gitlab.create_merge_request(project_id,"#{mr_title}",options={ source_branch: source_branch, target_branch: destination_branch, labels: gitlab_labels, assignee_id: assignee_id ,milestone_id: milestone_id } )
+
 

--- a/bin/rundeck_job_run.sh
+++ b/bin/rundeck_job_run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+
+repo_dir="$(dirname $0)/.."
+. "${repo_dir}/bin/functions"
+
+results_dir="${repo_dir}/tests/rundeck/$(date +%Y%m%d-%H%M%S)"
+mkdir -p $results_dir
+
+test -f /etc/gitlab-ci.conf && . /etc/gitlab-ci.conf
+env=$1
+default=${env}_query_default_nodes
+always=${env}_query_always_nodes
+default_nodes=${!default}
+always_nodes=${!always}
+nodes=0
+global_exit=0
+rdjobid=$(rd jobs list -G "Remote Command Execution" -J "Execute Puppet Agent command" --outformat %id)
+
+if [[ "x$1" != "x" ]]; then
+  git checkout $1
+  git pull
+fi
+
+runjob (){
+  echo
+  echo_title "Running Puppet on node ${1} - Check based on $2"
+  outfile=$results_dir/runjob.out    
+  rd run --id "${rdjobid}"  -F $1 -f -l verbose -- -noop true |tee $outfile
+  exitcode=$PIPESTATUS
+  if [ $exitcode -eq 1 ]; then
+    exitcode=$(cat $outfile | grep "Run of Puppet configuration client already in progress")
+  elif [ $exitcode -eq 2 ]; then
+    exitcode=0
+  else
+    exitcode=1
+  fi
+  global_exit=$(($global_exit + $exitcode))
+  rm -f $outfile
+}
+
+diff_commits_number=$(git log origin/production..$1 --pretty=oneline | wc -l)
+
+echo "Checking for files in the last $diff_commits_number commits"
+for changedfile in $(git diff HEAD~$diff_commits_number --name-only); do
+  node=''
+  if [[ $(echo "$changedfile" | grep -q 'data/nodes'; echo $?) -eq 0 ]]; then
+    node=$(echo $changedfile | sed -e "s/^data\/nodes\///" -e "s/\.yaml//")
+    nodes=$nodes+1
+  fi
+
+  if [[ "x$node" != "x" ]]; then
+    runjob "$node" "commits"
+  fi
+done
+
+# Default nodes to check if none found from the commit
+if [[ $nodes == 0 ]]; then
+  for node in ${default_nodes//,/ }; do
+    runjob "$node" "Default node"
+  done
+fi
+
+for node in ${always_nodes//,/ }; do
+  runjob "$node" "Always run node"
+done
+
+exit $global_exit

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -1,40 +1,23 @@
 ---
+# profile::gitlab::cli
+  profile::gitlab::cli::ensure: 'present'
+  profile::gitlab::cli::auto_prerequisites: true
+  profile::gitlab::cli::template: 'profile/gitlab/cli/gitlab-cli.conf.epp'
+  profile::gitlab::cli::config_hash:
+    project_id: ''
+    private_token: ''
+    api_endpoint: "https://gitlab.%{facts.domain}/api/v3"
+    httparty_options: '{verify: false}'
+    assigned_user: ''
+    milestone: ''
+    labels: 'automerge'
+    add_target_label: false
+    add_source_label: false
+    prefix_target_label: 'TO_'
+    prefix_source_label: 'FROM_'
+
 # profile::backup::legato
 profile::backup::legato::packages: []
-
-# profile::base::linux
-profile::base::linux::enable: true
-profile::base::linux::network_class: ''
-profile::base::linux::mail_class: ''
-profile::base::linux::puppet_class: ''
-profile::base::linux::ssh_class: ''
-profile::base::linux::users_class: ''
-profile::base::linux::sudo_class: ''
-profile::base::linux::monitor_class: ''
-profile::base::linux::firewall_class: ''
-profile::base::linux::logs_class: ''
-profile::base::linux::backup_class: ''
-profile::base::linux::time_class: ''
-profile::base::linux::timezone_class: ''
-profile::base::linux::sysctl_class: ''
-profile::base::linux::dns_class: ''
-profile::base::linux::hardening_class: ''
-profile::base::linux::hostname_class: ''
-profile::base::linux::hosts_class: ''
-profile::base::linux::update_class: ''
-profile::base::linux::motd_class: ''
-profile::base::linux::profile_class: ''
-
-# profile::base::solaris
-profile::base::solaris::enable: true
-profile::base::solaris::network_class: ''
-profile::base::solaris::mail_class: ''
-profile::base::solaris::puppet_class: ''
-profile::base::solaris::users_class: ''
-profile::base::solaris::monitor_class: ''
-profile::base::solaris::firewall_class: ''
-profile::base::solaris::logs_class: ''
-profile::base::solaris::backup_class: ''
 
 # profile::firewall::iptables
 profile::firewall::iptables::package_name: 'iptables'

--- a/site/profile/manifests/gitlab/cli.pp
+++ b/site/profile/manifests/gitlab/cli.pp
@@ -14,34 +14,23 @@
 #                the class
 #
 class profile::gitlab::cli (
-  String           $ensure             = 'present',
-  Boolean          $auto_prerequisites = true,
-  Optional[String] $template           = 'profile/gitlab/cli/gitlab-cli.conf.erb',
-  Hash             $extra_options      = { },
-
-  String           $private_token      = '',
-  String           $api_endpoint       = "https://gitlab.${::domain}/api/v3",
-  String           $project_id         = '1',
+  String           $ensure,
+  Boolean          $auto_prerequisites,
+  Optional[String] $template,
+  Hash             $config_hash,
 
 ) {
 
-  $options_default = {
-    'GITLAB_API_ENDPOINT' => $api_endpoint,
-    'GITLAB_API_PRIVATE_TOKEN' => $private_token,
-    'GITLAB_API_HTTPARTY_OPTIONS' => '{verify: false}', # Need for self signed https
-    'GITLAB_API_PROJECT_ID' => $project_id,
-  }
-  $options = $options_default + $extra_options
   ::tp::install { 'gitlab-cli' :
     ensure             => $ensure,
     auto_prerequisites => $auto_prerequisites,
   }
-
   if $template {
     file { '/etc/gitlab-cli.conf':
       ensure  => $ensure,
-      content => template($template),
+      content => epp($template),
     }
   }
 
 }
+

--- a/site/profile/templates/gitlab/cli/gitlab-cli.conf.epp
+++ b/site/profile/templates/gitlab/cli/gitlab-cli.conf.epp
@@ -1,0 +1,13 @@
+# File managed by Puppet
+<%- $options=$::profile::gitlab::cli::config_hash %>
+GITLAB_API_ENDPOINT=<%= $options['api_endpoint'] %>
+GITLAB_API_PRIVATE_TOKEN=<%= $options['private_token'] %>
+GITLAB_API_HTTPARTY_OPTIONS='<%= $options['httparty_options'] %>'
+GITLAB_API_PROJECT_ID=<%= $options['project_id'] %>
+GITLAB_USER='<%= $options['assigned_user'] %>'
+GITLAB_MILESTONE='<%= $options['milestone'] %>'
+GITLAB_LABELS='<%= $options['labels'] %>'
+GITLAB_TARGET_LABEL=<%= $options['add_target_label'] %>
+GITLAB_SOURCE_LABEL=<%= $options['add_source_label'] %>
+GITLAB_DEFAULT_TARGET_LABEL='<%= $options['prefix_target_label'] %>'
+GITLAB_DEFAULT_SOURCE_LABEL='<%= $options['prefix_source_label'] %>'

--- a/vagrant/bin/vagrant-setup_papply.sh
+++ b/vagrant/bin/vagrant-setup_papply.sh
@@ -25,6 +25,9 @@ setup() {
     service pe-puppetserver restart
   fi
   ln -sf /etc/puppetlabs/code/environments/$puppet_env/hiera3.yaml /etc/puppetlabs/puppet/hiera.yaml
+#  Link the local repository keys
+  ln -sf /etc/puppetlabs/code/environments/$puppet_env/keys /etc/puppetlabs/keys
+
 }
 
 # Run setup only the first time

--- a/vagrant/bin/vm.sh
+++ b/vagrant/bin/vm.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 repo_dir="$(dirname $0)/../.."
 . "${repo_dir}/bin/functions"
+. "${repo_dir}/bin/config/proxysetup"
+. "${repo_dir}/bin/config/defaults"
 
 action=$1
 vm=$2
-env=$3
+env=${3-$vagrantenv}
+
+export VAGRANT_DOTFILE_PATH=$HOME/.vagrant
+mkdir -p $VAGRANT_DOTFILE_PATH
 
 if [ "x${env}" != "" ]; then
   cd "${repo_dir}/vagrant/environments/${env}"


### PR DESCRIPTION
* gitlab_create_merge_request.rb now has more parameters in the config files that will allow to add milestone, assign a user, add labels.
* gitlab_create_merge_request.rb check if a MR already exist and fail in that case.
* gitlab_accept_merge_request.rb will check the correct MR and will not take the first on.
* docker_run.sh to do fully customized docker run.
* vagrant_node_test.sh added option to halt and destroy vagrant box.
* vm.sh will create .vagrant under home of the user and set it as VAGRANT_HOME.
* codemanager_check_deploy.sh will try the check 6 time with 10 seconds between checks.
* manage gitlab cli option with default value in data and an epp template.
* gitlab_catalog_preview.sh and puppetdb_env_query.sh got some fixes (on exitcode).
* Done some changes to .gitlab-ci.yml to manage new scripts and capabilities.
