### PR TITLE
Fix distro detection for Red Hat and CentOS

### DIFF
--- a/bin/puppet_install.sh
+++ b/bin/puppet_install.sh
@@ -113,7 +113,10 @@ setup_windows() {
 setup_linux() {
   ARCH=$(uname -m | sed 's/x86_//;s/i[3-6]86/32/')
   if [ -f /etc/redhat-release ]; then
-      OS=$(cat /etc/redhat-release | cut -d ' ' -f 1)
+      OS=$(cat /etc/redhat-release | cut -d ' ' -f 1-2 | tr -d '[:space:]')
+      if [ "$OS" == "CentOSLinux" ] || [ "$OS" == "CentOSrelease" ] ; then
+        OS="CentOS"
+      fi
       majver=$(cat /etc/redhat-release | sed 's/[^0-9\.]*//g' | sed 's/ //g' | cut -d '.' -f 1)
   elif [ -f /etc/SuSE-release ]; then
       OS=sles


### PR DESCRIPTION
This has been tested with RHEL 6, RHEL7, CentOS 6, and CentOS 7.
See attached shell-output.txt file.
[shell-output.txt](https://github.com/example42/psick/files/1166365/shell-output.txt)
