### PR TITLE
fix erb syntax check

### DIFF
--- a/bin/puppet_check_syntax.sh
+++ b/bin/puppet_check_syntax.sh
@@ -61,7 +61,7 @@ if [ ! -z ${ERB} ] && [ ! -z ${RUBY} ]; then
   for i in $(find site -name '*.erb')
   do
     echo -ne "$i - "
-    err=$(${ERB} -x -T - "${i}" | ${RUBY} -c 2>&1)
+    err=$(${ERB} -P -x -T - "${i}" | ${RUBY} -c 2>&1)
     if [ $? = 0 ]; then
       echo_success "OK"
     else

--- a/bin/puppet_check_syntax_fast.sh
+++ b/bin/puppet_check_syntax_fast.sh
@@ -82,7 +82,7 @@ if [ ! -z ${ERB} ] && [ ! -z ${RUBY} ]; then
   for i in $(find site -name '*.erb')
   do
     echo -ne "$i - "
-    err=$(${ERB} -x -T - "${i}" | ${RUBY} -c 2>&1)
+    err=$(${ERB} -P -x -T - "${i}" | ${RUBY} -c 2>&1)
     if [ $? = 0 ]; then
       echo_success "OK"
     else


### PR DESCRIPTION
when using a template with a trailing % sign, the syntax check fails when not using -P