### PR TITLE
lint work

### DIFF
--- a/Gemfile.puppetlint
+++ b/Gemfile.puppetlint
@@ -10,9 +10,9 @@ gem 'puppet-lint-appends-check',
 gem 'puppet-lint-classes_and_types_beginning_with_digits-check',
     :git => 'https://github.com/voxpupuli/puppet-lint-classes_and_types_beginning_with_digits-check.git',
     :require => false
-gem 'puppet-lint-empty_string-check',
-    :git => 'https://github.com/voxpupuli/puppet-lint-empty_string-check.git',
-    :require => false
+#gem 'puppet-lint-empty_string-check',
+#    :git => 'https://github.com/voxpupuli/puppet-lint-empty_string-check.git',
+#    :require => false
 gem 'puppet-lint-file_ensure-check',
     :git => 'https://github.com/voxpupuli/puppet-lint-file_ensure-check.git',
     :require => false

--- a/site/profile/manifests/ci/octocatalog.pp
+++ b/site/profile/manifests/ci/octocatalog.pp
@@ -31,7 +31,7 @@ class profile::ci::octocatalog (
   } else {
     $private_key_path = "/home/${run_as_user}/${trusted['certname']}.pem"
     file { $private_key_path:
-      ensure => present,
+      ensure => file,
       owner  => $run_as_user,
       group  => $run_as_user,
       mode   => '0400',

--- a/site/profile/manifests/dns/resolver.pp
+++ b/site/profile/manifests/dns/resolver.pp
@@ -12,7 +12,7 @@ class profile::dns::resolver (
 
   if $::virtual != 'docker' {
     file { $resolver_path:
-      ensure  => present,
+      ensure  => file,
       content => template($resolver_template),
       owner   => 'root',
       group   => 'root',

--- a/site/profile/manifests/firewall/iptables.pp
+++ b/site/profile/manifests/firewall/iptables.pp
@@ -21,7 +21,7 @@ class profile::firewall::iptables (
   }
 
   file { $config_file_path:
-    ensure  => present,
+    ensure  => file,
     notify  => Service[$service_name],
     content => template($rules_template),
     mode    => '0640',
@@ -45,12 +45,12 @@ class profile::firewall::iptables (
     }
     'Suse': {
       file { '/usr/lib/systemd/system/iptables.service':
-        ensure  => present,
+        ensure  => file,
         content => template('profile/firewall/iptables.service.erb'),
         notify  => Service[$service_name],
       }
       file { '/etc/sysconfig/iptables.stop':
-        ensure  => present,
+        ensure  => file,
         content => template('profile/firewall/iptables.stop.erb'),
         notify  => Service[$service_name],
       }

--- a/site/profile/manifests/hardening/network.pp
+++ b/site/profile/manifests/hardening/network.pp
@@ -20,19 +20,19 @@ class profile::hardening::network (
   if $::osfamily == 'RedHat' {
     if $modprobe_template != '' {
       file { '/etc/modprobe.d/hardening.conf':
-        ensure  => present,
+        ensure  => file,
         content => template($modprobe_template),
       }
     }
     if $blacklist_template != '' {
       file { '/etc/modprobe.d/blacklist-nouveau.conf':
-        ensure  => present,
+        ensure  => file,
         content => template($blacklist_template),
       }
     }
     if $netconfig_template != '' {
       file { '/etc/netconfig':
-        ensure  => present,
+        ensure  => file,
         content => template($netconfig_template),
       }
     }
@@ -40,7 +40,7 @@ class profile::hardening::network (
 
   if $services_template != '' {
     file { '/etc/services':
-      ensure  => present,
+      ensure  => file,
       content => template($services_template),
     }
   }

--- a/site/profile/manifests/hardening/pam.pp
+++ b/site/profile/manifests/hardening/pam.pp
@@ -63,7 +63,7 @@ class profile::hardening::pam (
 
   if $login_defs_template != '' {
     file { '/etc/login.defs':
-      ensure  => present,
+      ensure  => file,
       content => template($login_defs_template),
       owner   => root,
       group   => root,

--- a/site/profile/manifests/hardening/securetty.pp
+++ b/site/profile/manifests/hardening/securetty.pp
@@ -12,7 +12,7 @@ class profile::hardening::securetty (
 ){
   $ttys = join( $root_ttys, "\n")
   file { '/etc/securetty':
-    ensure  => present,
+    ensure  => file,
     content => template( $securetty_template ),
     owner   => root,
     group   => root,

--- a/site/profile/manifests/hardening/tcpwrappers.pp
+++ b/site/profile/manifests/hardening/tcpwrappers.pp
@@ -14,7 +14,7 @@ class profile::hardening::tcpwrappers (
 
   if $hosts_allow_template != '' {
     file { '/etc/hosts.allow':
-      ensure  => present,
+      ensure  => file,
       mode    => '0644',
       owner   => 'root',
       group   => 'root',
@@ -24,7 +24,7 @@ class profile::hardening::tcpwrappers (
 
   if $hosts_deny_template != '' {
     file { '/etc/hosts.deny':
-      ensure  => present,
+      ensure  => file,
       mode    => '0644',
       owner   => 'root',
       group   => 'root',

--- a/site/profile/manifests/hostname.pp
+++ b/site/profile/manifests/hostname.pp
@@ -19,7 +19,7 @@ class profile::hostname (
 
   if $::virtual != 'docker' {
     file { '/etc/hostname':
-      ensure  => present,
+      ensure  => file,
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
@@ -44,7 +44,7 @@ class profile::hostname (
       case $::osfamily {
         'RedHat': {
           file { '/etc/sysconfig/network':
-            ensure  => present,
+            ensure  => file,
             content => "NETWORKING=yes\nNETWORKING_IPV6=no\nHOSTNAME=${calc_fqdn}\n",
             notify  => Exec['apply_hostname'],
           }
@@ -55,7 +55,7 @@ class profile::hostname (
 
     if $update_cloud_cfg {
       file { '/etc/cloud/cloud.cfg.d/99_preserve_hostname.cfg':
-        ensure  => present,
+        ensure  => file,
         content => "preserve_hostname: true\n",
         notify  => Exec['apply_hostname'],
       }

--- a/site/profile/manifests/hosts/file.pp
+++ b/site/profile/manifests/hosts/file.pp
@@ -20,7 +20,7 @@ class profile::hosts::file (
   $extra_hosts=hiera_array('profile::hosts::file::extra_hosts', [] )
 
   file { '/etc/hosts':
-    ensure  => present,
+    ensure  => file,
     content => template($template),
   }
 

--- a/site/profile/manifests/icingaweb2.pp
+++ b/site/profile/manifests/icingaweb2.pp
@@ -59,7 +59,7 @@ class profile::icingaweb2 (
     augeas { 'php_date_timezone':
       context => '/files/etc/php.ini/DATE',
       changes => [
-        "set date.timezone ${::profile::settings::timezone}"
+        "set date.timezone ${::profile::settings::timezone}",
       ],
     }
   }

--- a/site/profile/manifests/network.pp
+++ b/site/profile/manifests/network.pp
@@ -21,7 +21,7 @@ class profile::network (
   include ::network
 
   file { '/etc/modprobe.d/bonding.conf':
-    ensure => present,
+    ensure => file,
   }
   $routes = hiera_hash('profile::network::routes', {})
   $routes.each |$r,$o| {
@@ -66,7 +66,7 @@ class profile::network (
   and $network_template != ''
   and $::profile::base::linux::hostname_class != '' {
     file { '/etc/sysconfig/network':
-      ensure  => 'present',
+      ensure  => file,
       content => template($network_template),
     }
   }

--- a/site/profile/manifests/oracle/install/orarun.pp
+++ b/site/profile/manifests/oracle/install/orarun.pp
@@ -16,11 +16,11 @@ class profile::oracle::install::orarun (
 
   package { 'orarun': }
   file { '/etc/sysconfig/oracle':
-    ensure  => present,
+    ensure  => file,
     content => template($sysconfig_template),
   }
   file { '/etc/profile.d/oracle.sh':
-    ensure  => present,
+    ensure  => file,
     content => template($profile_template),
   }
 

--- a/site/profile/manifests/oracle/prerequisites/limits.pp
+++ b/site/profile/manifests/oracle/prerequisites/limits.pp
@@ -42,7 +42,7 @@ class profile::oracle::prerequisites::limits (
 
   if $template and $template != '' {
     file { '/etc/security/limits.conf':
-      ensure  => 'present',
+      ensure  => file,
       content => template($template),
     }
   }

--- a/site/profile/manifests/oracle/prerequisites/sysctl.pp
+++ b/site/profile/manifests/oracle/prerequisites/sysctl.pp
@@ -70,7 +70,7 @@ class profile::oracle::prerequisites::sysctl (
 
   if $template and $template != '' {
     file { '/etc/sysctl.conf':
-      ensure  => 'present',
+      ensure  => file,
       content => template($template),
     }
   }

--- a/site/profile/manifests/oracle/prerequisites/users.pp
+++ b/site/profile/manifests/oracle/prerequisites/users.pp
@@ -40,20 +40,20 @@ class profile::oracle::prerequisites::users (
     },
     kmdba => {
       gid => '705',
-    }
+    },
   }
 
   $asm_groups = $has_asm ? {
     true => {
-      asmdba => {
-        gid => '706',
+      'asmdba' => {
+        'gid' => '706',
       },
-      asmadmin => {
-        gid => '707',
+      'asmadmin' => {
+        'gid' => '707',
       },
-      asmoper => {
-        gid => '708',
-      }
+      'asmoper' => {
+        'gid' => '708',
+      },
     },
     false => { },
   }
@@ -94,7 +94,7 @@ class profile::oracle::prerequisites::users (
       home    => '/home/gridora',
       require => Group['oinstall'],
       managehome => true,
-    }
+    },
   }
 
   $all_users = $use_defaults ? {

--- a/site/profile/manifests/puppet/pe_code_manager.pp
+++ b/site/profile/manifests/puppet/pe_code_manager.pp
@@ -47,13 +47,13 @@ class profile::puppet::pe_code_manager (
   }
 
   file { $deploy_ssh_private_key_path:
-    ensure => present,
+    ensure => file,
     owner  => $puppet_user,
     mode   => '0400',
     source => pick($deploy_ssh_private_source,"file://${real_deploy_user_home}/.ssh/id_rsa"),
   }
   file { $deploy_ssh_public_key_path:
-    ensure => present,
+    ensure => file,
     owner  => $puppet_user,
     mode   => '0400',
     source => pick($deploy_ssh_public_source,"file:///${real_deploy_user_home}/.ssh/id_rsa.pub"),

--- a/site/profile/manifests/sudo.pp
+++ b/site/profile/manifests/sudo.pp
@@ -20,7 +20,7 @@ class profile::sudo (
 
   if $sudoers_template != '' {
     file { '/etc/sudoers':
-      ensure  => present,
+      ensure  => file,
       mode    => '0440',
       owner   => 'root',
       group   => 'root',

--- a/site/profile/manifests/timezone.pp
+++ b/site/profile/manifests/timezone.pp
@@ -68,7 +68,7 @@ class profile::timezone(
 
   if $::virtual != 'docker' {
     file { 'timezone':
-      ensure  => present,
+      ensure  => file,
       path    => $config_file,
       mode    => '0644',
       owner   => 'root',

--- a/site/profile/manifests/update.pp
+++ b/site/profile/manifests/update.pp
@@ -27,7 +27,7 @@ class profile::update (
     # Custom update script
     if $cron_schedule != '' {
       file { '/etc/cron.d/system_update':
-        ensure  => present,
+        ensure  => file,
         content => "# File managed by Puppet\n${cron_schedule} root ${update_script_path}\n",
       }
     } else {
@@ -37,7 +37,7 @@ class profile::update (
     }
 
     file { $update_script_path:
-      ensure  => present,
+      ensure  => file,
       mode    => '0750',
       content => template($update_template),
       before  => File['/etc/cron.d/system_update'],

--- a/site/tools/manifests/mongo/command.pp
+++ b/site/tools/manifests/mongo/command.pp
@@ -30,7 +30,7 @@ define tools::mongo::command (
     default => "/${db_name}",
   }
   file { $mongodb_script_user:
-    ensure  => present,
+    ensure  => file,
     mode    => '0600',
     owner   => 'root',
     group   => 'root',


### PR DESCRIPTION
- remove empty string check
- clean file present

4 Warnings left:
site/profile/manifests/aws/puppet/vpc.pp - WARNING: spaceship operator without tag on line 17
site/profile/manifests/aws/puppet/vpc.pp - WARNING: spaceship operator without tag on line 18
site/profile/manifests/aws/puppet/vpc.pp - WARNING: spaceship operator without tag on line 19
site/tools/manifests/user/managed.pp - WARNING: undef passed to a function on line 197