### PR TITLE
run acceptance tests also for newer puppet versions (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Your contribution here.
 
+* [#220](https://github.com/example42/psick/pull/220): Run acceptance tests also for newer puppet versions - [@tuxmea](https://github.com/tuxmea).
+
 ## Release 0.9.2 - Second alpha for version 1.0.0
 * Updated docs to reflect new separated psick module layout [@alvagante](https://github.com/alvagante)
 * Several fixes to data and samples [@alvagante](https://github.com/alvagante)

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,7 +19,7 @@ if !has_puppet_changes && has_spec_changes
 end
 
 # Hiera changes
-if !has_hiera_changes
+if has_hiera_changes
   message('There are changes on Hiera files. They will probably affect one or more nodes.', sticky: false)
 end
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -57,10 +57,6 @@ mod 'puppetlabs/dummy_service', :latest
 # mod 'herculesteam-augeasproviders_sysctl', '2.2.0'
 # mod 'puppetlabs/firewall', :latest
 
-# Used by psick::vpn::openvpn
-# mod 'luxflux/openvpn',
-#  :git => 'https://github.com/luxflux/puppet-openvpn'
-
 # Used by psick::vagrant
 mod 'unibet/vagrant', :latest
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,28 +1,33 @@
 ---
-# Noop mode. Uncomment to enable nood mode globally
+# Noop mode. Uncomment to enable server side noop mode globally
 # noop_mode: true
 
-# General psick settings
+# General psick settings. These are the default values.
 psick::manage: true
-psick::auto_conf: hardened
+psick::auto_conf: none
 psick::auto_prereq: true
 
 # Tiny Puppet settings in psick module
-# By default tp integrations are not enabled. We want some of them:
+# By default tp integrations are not enabled. We want to install the tp cli
+# command and add tp test entries wherever possible. The default tinydata module
+# is used as data source for tp defines.
 psick::tp:
   cli_enable: true
   test_enable: true
+  data_module: tinydata
 
-# First run optional settings
+# First run optional settings. Here first run mode is disabled
 psick::enable_firstrun: false
 psick::firstrun::linux_classes:
   hostname: psick::hostname
 psick::firstrun::windows_classes:
   hostname: psick::hostname
 
-# Common Linux classes
+# PSICK classification for Linux nodes
+# We define the classes we want in pre phase (applied before all the others)
+# and in the base phase (common baseline, applied to all nodes)
 psick::pre::linux_classes:
-  puppet: puppet
+  puppet: psick::puppet
   puppet_gems: psick::puppet::gems
   hostname: psick::hostname
   hosts: psick::hosts::resource
@@ -42,7 +47,7 @@ psick::base::linux_classes:
   network: network
   systat: psick::monitor::sar
 
-# Pre and Base psick settings Windows
+# PSICK classification for Windows nodes
 psick::pre::windows_classes:
   hosts: psick::hosts::resource
 psick::base::windows_classes:
@@ -65,12 +70,11 @@ psick::timezone: UTC
 # Hostname and network settings
 psick::hostname::update_network_entry: false # Avoid resource duplication when psick::network is used
 
-# Postfix configuration
+# General postfix configuration
 psick::postfix::tp::resources_hash:
   tp::conf:
     postfix:
       template: 'psick/postfix/main.cf.erb'
-
 psick::postfix::tp::options_hash:
   'mydomain': "%{facts.domain}"
   'myhostname': "%{facts.hostname}"
@@ -81,3 +85,4 @@ psick::postfix::tp::options_hash:
 # Sample sysctl settings
 psick::sysctl::settings_hash:
   net.ipv4.conf.all.forwarding: 0
+

--- a/hieradata/nodes/jenkins.foss.psick.io.yaml
+++ b/hieradata/nodes/jenkins.foss.psick.io.yaml
@@ -1,10 +1,11 @@
 ---
 # We need jenkins class in base classes to avoid dependency loops
 # Other classes are needed to test Puppet code
+psick::pre::linux_classes:
+  rubybuild: psick::ruby::buildgems
 psick::base::linux_classes:
   jenkins: psick::jenkins
   docker: psick::docker
-  rubybuild: psick::ruby::buildgems
   pdk: psick::puppet::pdk
   vagrant: psick::vagrant
   git: psick::git
@@ -18,8 +19,8 @@ psick::docker::allowed_users:
   - jenkins
 
 # Enabled and configure scm-sync plugin
-psick::jenkins::scm_sync_repository_url: git@github.com:alvagante/jenkins.lab.psick.io-scmsync.git
-psick::jenkins::scm_sync_repository_host: github.com
+psick::jenkins::scm_sync_repository_url: git@github.com:alvagante/jenkins.foss.psick.io-scmsync.git
+# psick::jenkins::scm_sync_repository_host: github.com
 psick::jenkins::disable_setup_wizard: true
 
 # Generate jenkins ssh keypair
@@ -47,6 +48,9 @@ psick::jenkins::plugins:
     enable: true
   blueocean:
     enable: true
+  scm-sync-configuration:
+    enable: true
+
 
 # Install gems needed for Ci tests only in Puppet environment.
 # Use a default set of gems for integration tests
@@ -78,4 +82,19 @@ psick::puppet::ci::options:
   catalog_preview_default_nodes:
     - lamp.foss.psick.io
     - puppet.foss.psick.io
+
+psick::openssh::configs_hash:
+  jenkins:
+    path: /var/lib/jenkins/.ssh/config
+    create_ssh_dir: true
+    options_hash:
+      Host puppet.foss.psick.io:
+        StrictHostKeyChecking: no
+        UserKnownHostsFile: /dev/null
+      Host puppet:
+        StrictHostKeyChecking: no
+        UserKnownHostsFile: /dev/null
+      Host github.com:
+        StrictHostKeyChecking: no
+        UserKnownHostsFile: /dev/null
 

--- a/hieradata/nodes/jenkins.lab.psick.io.yaml
+++ b/hieradata/nodes/jenkins.lab.psick.io.yaml
@@ -21,7 +21,7 @@ psick::docker::allowed_users:
 
 # Enabled and configure scm-sync plugin
 psick::jenkins::scm_sync_repository_url: git@github.com:alvagante/jenkins.lab.psick.io-scmsync.git
-psick::jenkins::scm_sync_repository_host: github.com
+# psick::jenkins::scm_sync_repository_host: github.com
 psick::jenkins::disable_setup_wizard: true
 
 # Generate jenkins ssh keypair
@@ -80,4 +80,19 @@ psick::puppet::ci::options:
   catalog_preview_default_nodes:
     - lamp.lab.psick.io
     - puppet.lab.psick.io
+
+psick::openssh::configs_hash:
+  jenkins:
+    path: /var/lib/jenkins/.ssh/config
+    create_ssh_dir: true
+    options_hash:
+      Host puppet.lab.psick.io:
+        StrictHostKeyChecking: no
+        UserKnownHostsFile: /dev/null
+      Host puppet:
+        StrictHostKeyChecking: no
+        UserKnownHostsFile: /dev/null
+      Host github.com:
+        StrictHostKeyChecking: no
+        UserKnownHostsFile: /dev/null
 

--- a/hieradata/nodes/puppet.foss.psick.io.yaml
+++ b/hieradata/nodes/puppet.foss.psick.io.yaml
@@ -1,18 +1,16 @@
 ---
-psick::profiles::linux_classes:
-  - psick::puppet::foss_master
-  - psick::puppet::foss_server_metrics
+psick::base::linux_classes:
+  puppetdb: psick::puppetdb
+  puppetserver: psick::puppetserver
 
 psick::puppet::gems::install_gems: []
 psick::puppet::gems::default_set: 'master'
 psick::puppet::gems::install_system_gems: false
-psick::puppet::gems::install_puppetserver_gems: true
 
 psick::puppet::foss_server_metrics::graphite_server: 'grafana.foss.psick.io'
 
-psick::puppet::foss_master::git_remote_repo: https://github.com/example42/psick.git
-psick::puppet::foss_master::dns_alt_names: "puppet, puppet.%{::domain}"
-psick::puppet::foss_master::remove_global_hiera_yaml: true
-psick::puppet::foss_master::manage_puppetdb_repo: true
-psick::puppet::foss_master::enabled_puppetdb: true
+psick::puppetserver::git_remote_repo: https://github.com/example42/psick.git
+psick::puppetserver::dns_alt_names: "puppet, puppet.%{::domain}"
+psick::puppetserver::remove_global_hiera_yaml: true
 
+psick::puppetdb::postgresql_class: 'psick::postgresql::tp'

--- a/hieradata/role/puppetdb.yaml
+++ b/hieradata/role/puppetdb.yaml
@@ -1,4 +1,4 @@
 ---
 psick::profiles::linux_classes:
-  puppetdb: '::puppet::profile::puppetdb'
+  puppetdb: '::psick::puppetdb::tp'
 

--- a/hieradata/role/puppetserver.yaml
+++ b/hieradata/role/puppetserver.yaml
@@ -1,7 +1,6 @@
 ---
 psick::profiles::linux_classes:
-  puppetserver: puppet::profile::server
+  puppetserver: psick::puppetserver::tp
 
-# Sample settings for a small footprint devel server
-# puppet::profile::server::options:
+# psick::puppetserver::options_hash:
 #   java_args: '-Xms512m -Xmx512m -XX:MaxPermSize=256m'

--- a/hieradata/zone/foss.yaml
+++ b/hieradata/zone/foss.yaml
@@ -1,0 +1,55 @@
+---
+### Classification
+psick::pre::linux_classes:
+  hosts: psick::hosts::file
+psick::base::linux_classes:
+  dns: '' # In lab we leave DNS unmanaged
+
+psick::puppet::gems::install_system_gems: false
+psick::puppet::gems::install_gems:
+  - msgpack
+
+# Disabled updating host entry by psick::hostname
+psick::hostname::update_host_entry: false
+# Hosts file managed via file resource
+psick::hosts::file::extra_hosts:
+  - '10.42.49.101 puppet puppet.foss.psick.io'
+  - '10.42.49.102 git git.foss.psick.io'
+  - '10.42.49.103 cirunner cirunner.foss.psick.io'
+  - '10.42.49.105 build build.lab.psick.io'
+  - '10.42.49.106 docker docker.foss.psick.io'
+  - '10.42.49.107 jenkins jenkins.foss.psick.io'
+
+# Enable automatic updates on lab nodes and set schedule:
+psick::update::cron_schedule: '4 4 * * *'
+
+#Timezone
+psick::timezone: 'Europe/Berlin'
+psick::timezone::timezone_windows: 'Central European Standard Time'
+
+# Users
+# psick::users::root_pw: hash_as_in_etc_shadow
+psick::users::delete_unmanaged: false
+psick::users::module: 'user'
+psick::users::users_hash:
+  al:
+    ensure: present
+    comment: 'Al'
+    groups:
+      - users
+
+# OpenSSH
+psick::openssh::tp::resources_hash:
+  tp::conf:
+    openssh:
+      template: 'psick/generic/spaced.erb'
+      options_hash:
+        Protocol: 2
+        PermitRootLogin: 'no'
+        Subsystem: 'sftp /usr/libexec/openssh/sftp-server'
+
+# Bolt
+psick::bolt::master: puppet.lab.psick.io
+psick::bolt::keyshare_method: storeconfigs
+psick::bolt::ssh_user: bolt
+

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,10 +1,24 @@
 require 'beaker-rspec'
 require 'beaker-hiera'
 require 'beaker/puppet_install_helper'
+begin
+  require 'puppet'
+rescue TypeError
+end
 
 hosts.each do |host|
   # Install Puppet
-  install_puppet_agent_on(host)
+  # check for puppet version
+  case Puppet.version.to_i
+  when 4
+    version_to_install = '1.' + Puppet.version.split('.')[1..-1]*"."
+    install_puppet_agent_on(host, {:version => version_to_install})
+  when 5
+    install_puppet_agent_on(host, {:version => Puppet.version,:puppet_collection => 'puppet5'})
+  else
+    puts 'unsupported puppet version'
+    exit
+  end
 end
 
 RSpec.configure do |c|

--- a/vagrant/environments/foss/config.yaml
+++ b/vagrant/environments/foss/config.yaml
@@ -75,6 +75,9 @@ nodes:
   - role: jenkins
     count: 1
     box: ubuntu1604
+    forwarded_port:
+      guest: 8080
+      host: 19481
   - role: ostest
     hostname_base: centos6
     count: 1


### PR DESCRIPTION
* run acceptance tests also for newer puppet versions

reusing the PUPPET_GEM_VERSION environment variable which is also taken
for rspec-puppet.

* switch from PUPPET_GEM_VERSION to installed puppet version

* remove pry

* smarter handling of installing specific puppet versions

Add full path to Jenkinsfile bundle

starting works on foss setup

Works on foss vagrant env + docs

Fixed wrong hiera files chnagesdetection in Dangerfile

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's a new profile got with the PR (possibly with docs, samples and tests)

## After submitting your PR

  1. Verify Travis checks and fix the errors if needed
  1. Feel free to ping us if we don't reply promptly 

