### PR TITLE
Improvements in Vagrant

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -94,7 +94,7 @@ We can customise the vagrant environments in various ways:
 
   - Customise eventually the same ```Vagrantfile``` for our own needs.
 
-#### Editing config.yaml
+### Editing config.yaml
 
 The ```config.yaml``` file is used by the local Vagrantfile to customise easily the VMs we want to use.
 
@@ -155,6 +155,49 @@ Finally it's possible to define the Vagrant boxes to use for the different VMs, 
       ubuntu1404:                             # Another box
         box: puppetlabs/ubuntu-14.04-64-puppet
 
+#### Environments
+
+In config.yaml there are some options involving which code will be run on host.
+
+* `puppet > environment`: The environment to apply to the virtual machine
+
+* `puppet > link_controlrepo`: Add a link for a Puppet environment to the development control-repo.  
+  Setting this to true will create an environment "`host`" with our current uncommitted code.
+
+* `puppet > controlrepo`: URL of the controlrepo to deploy via r10k on Puppet Server.  
+  Can be both a local or our local control repo:
+    * `https://git.organization.tld/puppet.git`
+    * `/vagrant_puppet` to use the local dir.
+
+#### Agent or masterless?
+
+We can execute the code in masterless mode or connecting to a puppet master inside vagrant environment.
+
+* `vm > puppet_agent`: If set to true this will run puppet agent, connecting to master configured in `puppet::master_fqdn`
+
+* `vm > puppet_apply`: If set to false this will apply catalog, in masterless mode. This is mandatory to bootstrap the puppet master.
+
+We can set both true to run puppet twice, fist in masterless mode, then run the agent.
+
+#### Override options for each node
+
+The `node` key is an array of hosts to run. Here, we can override each option in `vm` and `pupet`.  
+For example:
+
+```yaml
+  vm:
+    memory: 1024
+
+  puppet:
+    environment: production
+
+  node:
+  - role: puppet
+    memory: 6192
+    puppet_apply: true
+  - role: application_server
+    environment: host
+```
 
 #### Customising the Vagrantfile and the relevant scripts
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -171,7 +171,7 @@ Vagrant.configure('2') do |config|
         node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro']
         node_config.vm.provision 'shell', path: '../../bin/vagrant-linkcontrolrepo.sh', args: "#{puppet_environment} #{puppet_code_dir}" if link_controlrepo
         node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: "#{puppet_environment}"
-        node_config.vm.provision 'shell', path: '../../bin/papply.sh'
+        node_config.vm.provision 'shell', path: '../../bin/papply.sh', args: "#{puppet_environment}"
       end
 
       if node['pe_role'] == 'master'
@@ -195,7 +195,7 @@ Vagrant.configure('2') do |config|
       if node['forwarded_port2']
         node_config.vm.network 'forwarded_port', guest: node['forwarded_port2']['guest'], host: node['forwarded_port2']['host']
       end
- 
+
       node_config.vm.provider 'virtualbox' do |v|
         v.customize ['modifyvm', :id, '--name', fqdn]
         v.customize ['modifyvm', :id, '--cpus', node['cpu'].to_s]

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -14,7 +14,6 @@ unless File.exist?(config_file)
 end
 settings = YAML.load_file config_file
 
-
 boxes = YAML.load_file File.join(vagrantfile_dir, '../../boxes.yaml')
 
 # Network and Puppet basics
@@ -24,7 +23,7 @@ range_start_offset = settings['network']['ip_start_offset'] ? settings['network'
 puppet_master_hostname = settings['puppet']['master_fqdn'] ? settings['puppet']['master_fqdn'] : 'puppet'
 puppet_environment = settings['puppet']['environment']
 puppet_controlrepo = settings['puppet']['controlrepo'] ? settings['puppet']['controlrepo'] : false
-r10k_install = settings['puppet']['r10k_install'] ?  settings['puppet']['r10k_install'] : false
+r10k_install = settings['puppet']['r10k_install'] ? settings['puppet']['r10k_install'] : false
 
 # We mount this directory on the VMs and then link puppet_environment to it
 # This is needed to avoid Puppet installation issues complaining about limited space
@@ -41,19 +40,19 @@ if settings['nodes'].is_a?(Array)
     (1..count).each do |vm_index|
       vm = node.clone
       vm['hostname_base'] = vm['hostname_base'] ? vm['hostname_base'] : vm['role']
-      vm['hostname'] = "%s" % [vm['hostname_base']]
-      vm['fqdn'] = vm['fqdn'] ? vm['fqdn'] : "%s.%s" % [vm['hostname_base'], settings['network']['domain']]
+      vm['hostname'] = '%s' % [vm['hostname_base']]
+      vm['fqdn'] = vm['fqdn'] ? vm['fqdn'] : '%s.%s' % [vm['hostname_base'], settings['network']['domain']]
 
       if vm['ip_address']
         vm['ip'] = vm['ip_address']
       else
         vm['ip'] = network_ip_range[ip_index].to_s
-        ip_index+=1
+        ip_index += 1
       end
 
       vm['aliases'] = [
-          "%s.%s" % [vm['hostname'], settings['network']['domain']],
-          "%s-%02d" % [vm['hostname_base'], vm_index]
+        '%s.%s' % [vm['hostname'], settings['network']['domain']],
+        '%s-%02d' % [vm['hostname_base'], vm_index]
       ]
 
       vm['box'] = node['box'] ? node['box'] : settings['vm']['box']
@@ -67,7 +66,7 @@ if settings['nodes'].is_a?(Array)
       vm['role'] = node['role'] ? node['role'] : settings['vm']['role']
       vm['pe_role'] = node['pe_role'] ? node['pe_role'] : nil
       vm['pe_answer_file'] = node['pe_answer_file'] ? node['pe_answer_file'] : nil
-    #  vm['forwarded_port'] = node['forwarded_port'] ? node['forwarded_port'] : nil
+      #  vm['forwarded_port'] = node['forwarded_port'] ? node['forwarded_port'] : nil
       vm['application'] = node['application'] ? node['application'] : settings['puppet']['application']
       vm['install_oss'] = node['install_oss'] ? node['install_oss'] : settings['puppet']['install_oss']
       vm['install_pe'] = node['install_pe'] ? node['install_pe'] : settings['puppet']['install_pe']
@@ -80,7 +79,6 @@ end
 
 # Vagrant configuration
 Vagrant.configure('2') do |config|
-
   # hostmanager config
   if Vagrant.has_plugin?('vagrant-hostmanager')
     config.hostmanager.enabled = settings['vagrant']['hostmanager.enabled'] ? settings['vagrant']['hostmanager.enabled'] : true
@@ -90,9 +88,7 @@ Vagrant.configure('2') do |config|
   end
 
   # Cache packages if vagrant-cachier is present
-  if Vagrant.has_plugin?("vagrant-cachier")
-    config.cache.scope = :box
-  end
+  config.cache.scope = :box if Vagrant.has_plugin?('vagrant-cachier')
 
   # See https://github.com/mitchellh/vagrant/issues/1673
   config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
@@ -116,7 +112,7 @@ Vagrant.configure('2') do |config|
     pe_download_root = settings['puppet']['pe_download_root'] if settings['puppet']['pe_download_root']
     master_vm = settings['puppet']['master_vm'] if settings['puppet']['master_vm']
     # forwarded_port = node['forwarded_port']
-    vm_box = boxes['boxes']["#{box}"]['box']
+    vm_box = boxes['boxes'][box.to_s]['box']
     link_controlrepo = settings['puppet']['link_controlrepo'] ? settings['puppet']['link_controlrepo'] : false
     user = ENV['USER']
     vm_name = node['multi_user'] ? "#{user}-#{fqdn}" : fqdn
@@ -126,7 +122,7 @@ Vagrant.configure('2') do |config|
       node_config.vm.network :private_network, ip: node['ip']
       node_config.vm.network :private_network, ip: node['ipv6'] if node['ipv6']
 
-      node_config.vm.provision 'shell', path: '../../bin/vagrant-sethostname.sh', args: "#{fqdn}"
+      node_config.vm.provision 'shell', path: '../../bin/vagrant-sethostname.sh', args: fqdn.to_s
       node_config.vm.provision 'shell', path: '../../../bin/puppet_set_external_facts.sh', args: "--role #{role} --env #{env} --zone #{zone} --datacenter #{datacenter} --application #{application}" if node['facter_external_facts']
       node_config.vm.provision 'shell', path: '../../../bin/puppet_set_trusted_facts.sh', args: "--role #{role} --env #{env} --zone #{zone} --datacenter #{datacenter} --application #{application}" if node['facter_trusted_facts']
       node_config.vm.provision 'shell', path: '../../../bin/puppet_install.sh' if install_oss
@@ -163,25 +159,25 @@ Vagrant.configure('2') do |config|
       end
 
       if role == 'puppet'
-        node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_puppetserver.sh', args: "#{puppet_environment}"
+        node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_puppetserver.sh', args: puppet_environment.to_s
       end
 
       if node['puppet_apply'] == true
-        node_config.vm.provision 'shell', path: '../../../bin/puppet_deploy_controlrepo.sh', args: "#{puppet_controlrepo}" if r10k_install
+        node_config.vm.provision 'shell', path: '../../../bin/puppet_deploy_controlrepo.sh', args: puppet_controlrepo.to_s if r10k_install
         node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro']
         node_config.vm.provision 'shell', path: '../../bin/vagrant-linkcontrolrepo.sh', args: "#{puppet_environment} #{puppet_code_dir}" if link_controlrepo
-        node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: "#{puppet_environment}"
-        node_config.vm.provision 'shell', path: '../../bin/papply.sh', args: "#{puppet_environment}"
+        node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: puppet_environment.to_s
+        node_config.vm.provision 'shell', path: '../../bin/papply.sh', args: puppet_environment.to_s
       end
 
       if node['pe_role'] == 'master'
-        node_config.vm.synced_folder "../../../", puppet_code_dir, mount_options: ["ro"]
+        node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro']
         node_config.vm.provision 'shell', path: '../../bin/vagrant-linkcontrolrepo.sh', args: "#{puppet_environment} #{puppet_code_dir}" if link_controlrepo
-        node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: "#{puppet_environment}"
+        node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: puppet_environment.to_s
       end
 
       if node['puppet_agent'] == true
-        if Vagrant.has_plugin?('vagrant-pe_build') and install_pe
+        if Vagrant.has_plugin?('vagrant-pe_build') && install_pe
           node_config.vm.provision :pe_agent do |p|
             p.master_vm = master_vm
           end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -164,10 +164,10 @@ Vagrant.configure('2') do |config|
 
       if role == 'puppet'
         node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_puppetserver.sh', args: "#{puppet_environment}"
-        node_config.vm.provision 'shell', path: '../../../bin/puppet_deploy_controlrepo.sh', args: "#{puppet_controlrepo}" if r10k_install
       end
 
       if node['puppet_apply'] == true
+        node_config.vm.provision 'shell', path: '../../../bin/puppet_deploy_controlrepo.sh', args: "#{puppet_controlrepo}" if r10k_install
         node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro']
         node_config.vm.provision 'shell', path: '../../bin/vagrant-linkcontrolrepo.sh', args: "#{puppet_environment} #{puppet_code_dir}" if link_controlrepo
         node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: "#{puppet_environment}"

--- a/vagrant/bin/papply.sh
+++ b/vagrant/bin/papply.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-environment='host'
+
+environment=${1:-"host"}
 base_dir="/etc/puppetlabs/code/environments/${environment}"
-manifest=${1:-"${base_dir}/manifests/site.pp"}
+manifest=${2:-"${base_dir}/manifests/site.pp"}
 
 PATH=$PATH:/opt/puppetlabs/bin
 

--- a/vagrant/environments/foss/README.md
+++ b/vagrant/environments/foss/README.md
@@ -4,11 +4,17 @@ In this Vagrant environment machines are provisioned with Puppet Open Source.
 
 By default you have at disposal the ```puppet``` machine, who has a POS allinone installation, and other VMs for other roles, which use puppet agent on the puppet VM (which compiles catalogs based on code and data on this control-repo).
 
-Edit ```config.yaml``` in this directory to customise the VMs to test, the Puppet Open Source version to use and how you want your Vagrant environment to be.
+Edit ```config.yaml``` in this directory to customise the VMs to test, the Puppet Open Source version to use and how you want your Vagrant environment to be.  
+You can give a look to [config.yaml documentation here](/docs/vagrant.md#customisations).
 
 To work in this Vagrant environment:
 
     cd <your-control-repo-dir>
+
+    # Download or refresh modules listed in Puppetfile if needed
+    r10k puppetfile install -v
+
+    # Move to vagrant foss environment
     cd vagrant/environment/foss
 
     # Show available Vagrant machines
@@ -27,8 +33,6 @@ To work in this Vagrant environment:
     # They will run puppet agent pointing to the puppet vm
     vagrant up [vm]
 
-
 Note 1: It's recommended to run this Vagrant environment on hosts that have at least 8 Gb of RAM. Edit ```config.yaml``` to tune the memory to allocate to the VM.
 
 There is no web frontend for reporting at the moment. We are working on bootstrapping puppetboard onto the POS master.
-

--- a/vagrant/environments/foss/config.yaml
+++ b/vagrant/environments/foss/config.yaml
@@ -1,40 +1,40 @@
 ---
 # Default settings for all vms (they can be overridden on each node)
 vm:
-  memory: 1024                 # MB or RAM to assign
-  cpu: 1                       # Number of vCPU to assign to the VM
-  box: ubuntu1604              # Box used for the VM, from the box list in vagrant/boxes.yaml
-  puppet_apply: false          # Run puppet apply on the local control-repo during provisioning
-  puppet_agent: true           # Run puppet agent during provisioning
-  facter_external_facts: true  # Create external facts in facts.d/$fact.txt. Note 1
-  facter_trusted_facts: false  # Create csr_attributes.yaml. Note 1
+  memory: 1024                # MB or RAM to assign
+  cpu: 1                      # Number of vCPU to assign to the VM
+  box: ubuntu1604             # Box used for the VM, from the box list in vagrant/boxes.yaml
+  puppet_apply: false         # Run puppet apply on the local control-repo during provisioning
+  puppet_agent: true          # Run puppet agent during provisioning
+  facter_external_facts: true # Create external facts in facts.d/$fact.txt. Note 1
+  facter_trusted_facts: false # Create csr_attributes.yaml. Note 1
 
-# Note 1: Some facts are used in default hiera.yaml and needed for
+# Note 1:   Some facts are used in default hiera.yaml and needed for
 # nodes classification. So it's better to set them, once.
 # If you enable both external and trusted facts and keep the
-# default manifests/site.pp you'll have a variable declaration error 
+# default manifests/site.pp you'll have a variable declaration error
 
 # A local network is created among the VM. Here is configured.
 network:
-  range: 10.42.49.0/24   # Network address and mask to use 
-  ip_start_offset: 101   # Starting ip in the network for automatic assignement
-  domain: foss.psick.io    # Name of DNS domain for the created machines
+  range: 10.42.49.0/24  # Network address and mask to use
+  ip_start_offset: 101  # Starting ip in the network for automatic assignement
+  domain: foss.psick.io # Name of DNS domain for the created machines
 
 # Puppet related settings
 puppet:
-  version: latest             # Version to use for OSS
-  install_oss: true          # If to install Puppet OSS agent on the VMS
-  install_pe: false            # If to install Puppet Enterprise agent on the VMS
-  env: devel                  # Setting for the env fact (may be used in hiera.yaml)
-  zone: foss                  # Setting for the zone fact (may be used in hiera.yaml)
-  datacenter: vagrant         # Setting for the datacenter fact (may be used in hiera.yaml)
-  application: default        # Setting for the application fact (may be used in hiera.yaml)
-  master_vm:  puppet.foss.psick.io      # Name of the VM which play as Puppet server for the others
-  master_fqdn: 'puppet.foss.psick.io'   # FQDN of the Puppet server to use with puppet agent
-  link_controlrepo: true      # Add a link for a Puppet environment to the development control-repo
-  environment: host           # Puppet environment to link to local control-repo and to use when Vagrant provisioning
-  r10k_install: true          # If to run r10k on Puppet server to deploy controlrepo
-  controlrepo: /vagrant_puppet # URL of the controlrepo to deploy via r10k on Puppet Server
+  version: latest                     # Version to use for OSS
+  install_oss: true                   # If to install Puppet OSS agent on the VMS
+  install_pe: false                   # If to install Puppet Enterprise agent on the VMS
+  env: devel                          # Setting for the env fact (may be used in hiera.yaml)
+  zone: foss                          # Setting for the zone fact (may be used in hiera.yaml)
+  datacenter: vagrant                 # Setting for the datacenter fact (may be used in hiera.yaml)
+  application: default                # Setting for the application fact (may be used in hiera.yaml)
+  master_vm: puppet.foss.psick.io     # Name of the VM which play as Puppet server for the others
+  master_fqdn: 'puppet.foss.psick.io' # FQDN of the Puppet server to use with puppet agent
+  link_controlrepo: true              # Add a link for a Puppet environment to the development control-repo
+  environment: host                   # Puppet environment to link to local control-repo and to use when Vagrant provisioning
+  r10k_install: true                  # If to run r10k on Puppet server to deploy controlrepo
+  controlrepo: /vagrant_puppet        # URL of the controlrepo to deploy via r10k on Puppet Server
 
 # Vagrant settings
 vagrant:
@@ -45,7 +45,7 @@ vagrant:
 # it can be enforced a defined host name, added alieses, port forwarding and foss_role
 nodes:
   - role: puppet
-    application: puppetinfra  
+    application: puppetinfra
     foss_role: master
     puppet_apply: true
     memory: 6192
@@ -56,7 +56,7 @@ nodes:
       guest: 443
       host: 1943
   - role: gitlab
-    application: puppetinfra  
+    application: puppetinfra
     puppet_apply: true
     puppet_agent: 0
     memory: 2048
@@ -64,7 +64,7 @@ nodes:
     aliases:
       - git
     forwarded_port:
-      guest: 443
+      guest:     443
       host: 1944
   - role: icinga
     count: 1
@@ -89,4 +89,3 @@ nodes:
     hostname_base: centos7
     count: 1
     box: centos7
-

--- a/vagrant/environments/foss/config.yaml
+++ b/vagrant/environments/foss/config.yaml
@@ -31,10 +31,10 @@ puppet:
   application: default        # Setting for the application fact (may be used in hiera.yaml)
   master_vm:  puppet.foss.psick.io      # Name of the VM which play as Puppet server for the others
   master_fqdn: 'puppet.foss.psick.io'   # FQDN of the Puppet server to use with puppet agent
-  link_controlrepo: false     # Add a link for a Puppet environment to the development control-repo 
+  link_controlrepo: true      # Add a link for a Puppet environment to the development control-repo
   environment: host           # Puppet environment to link to local control-repo and to use when Vagrant provisioning
   r10k_install: true          # If to run r10k on Puppet server to deploy controlrepo
-  controlrepo: https://github.com/example42/psick.git # URL of the controlrepo to deploy via r10k on Puppet Server
+  controlrepo: /vagrant_puppet # URL of the controlrepo to deploy via r10k on Puppet Server
 
 # Vagrant settings
 vagrant:

--- a/vagrant/environments/foss/config.yaml
+++ b/vagrant/environments/foss/config.yaml
@@ -58,6 +58,7 @@ nodes:
   - role: gitlab
     application: puppetinfra  
     puppet_apply: true
+    puppet_agent: 0
     memory: 2048
     cpu: 2
     aliases:


### PR DESCRIPTION
Testing vagrant foss environment i've found a pair of problems, mostly on `github` node. 

* `papply.sh`  uses an hardcoded environment, not the env in `config.yaml` file
* gitlab runs puppet twice: `puppet apply` and `puppet agent` failing during `agent` if no puppet server runs

Docs: 
* add some `config.yaml` tips & tricks
* vagrant foss readme

I've also linted Vagrantfile and config.yaml
