### PR TITLE
Fix #256; adds config to folder sync type

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -62,6 +62,7 @@ if settings['nodes'].is_a?(Array)
       vm['puppet_apply'] = node['puppet_apply'] ? node['puppet_apply'] : settings['vm']['puppet_apply']
       vm['facter_external_facts'] = node['facter_external_facts'] ? node['facter_external_facts'] : settings['vm']['facter_external_facts']
       vm['facter_trusted_facts'] = node['facter_trusted_facts'] ? node['facter_trusted_facts'] : settings['vm']['facter_trusted_facts']
+      vm['synced_folder_type'] = node['synced_folder_type'] ? node['synced_folder_type'] : settings['vm']['synced_folder_type']
 
       vm['role'] = node['role'] ? node['role'] : settings['vm']['role']
       vm['pe_role'] = node['pe_role'] ? node['pe_role'] : nil
@@ -164,14 +165,14 @@ Vagrant.configure('2') do |config|
 
       if node['puppet_apply'] == true
         node_config.vm.provision 'shell', path: '../../../bin/puppet_deploy_controlrepo.sh', args: puppet_controlrepo.to_s if r10k_install
-        node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro']
+        node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro'], type: node['synced_folder_type']
         node_config.vm.provision 'shell', path: '../../bin/vagrant-linkcontrolrepo.sh', args: "#{puppet_environment} #{puppet_code_dir}" if link_controlrepo
         node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: puppet_environment.to_s
         node_config.vm.provision 'shell', path: '../../bin/papply.sh', args: puppet_environment.to_s
       end
 
       if node['pe_role'] == 'master'
-        node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro']
+        node_config.vm.synced_folder '../../../', puppet_code_dir, mount_options: ['ro'], type: node['synced_folder_type']
         node_config.vm.provision 'shell', path: '../../bin/vagrant-linkcontrolrepo.sh', args: "#{puppet_environment} #{puppet_code_dir}" if link_controlrepo
         node_config.vm.provision 'shell', path: '../../bin/vagrant-setup_papply.sh', args: puppet_environment.to_s
       end

--- a/vagrant/environments/bare/config.yaml
+++ b/vagrant/environments/bare/config.yaml
@@ -8,6 +8,7 @@ vm:
   puppet_agent: false
   facter_external_facts: false
   facter_trusted_facts: false
+  synced_folder_type: vboxfs    # Sync folders types: nfs, vboxfs
 
 network:
   range: 10.42.40.0/24

--- a/vagrant/environments/ci/config.yaml
+++ b/vagrant/environments/ci/config.yaml
@@ -6,6 +6,7 @@ vm:
   box: centos7                 # Box used for the VM, from the box list in vagrant/boxes.yaml
   puppet_apply: false          # Run puppet apply on the local control-repo during provisioning
   puppet_agent: true           # Run puppet agent during provisioning
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 network:
   range: 10.42.41.0/24

--- a/vagrant/environments/demo/config.yaml
+++ b/vagrant/environments/demo/config.yaml
@@ -8,6 +8,7 @@ vm:
   puppet_agent: true           # Run puppet agent during provisioning
   facter_external_facts: false # Create external facts in facts.d/$fact.txt. Note 1
   facter_trusted_facts: true   # Create csr_attributes.yaml. Note 1
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 # Note 1: Some facts are used in default hiera.yaml and needed for
 # nodes classification. So it's better to set them, once.

--- a/vagrant/environments/docker/config.yaml
+++ b/vagrant/environments/docker/config.yaml
@@ -6,6 +6,7 @@ vm:
   box: centos7 # From boxes list below
   puppet_apply: true
   puppet_agent: false
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 network:
   range: 10.42.42.0/24

--- a/vagrant/environments/foreman/config.yaml
+++ b/vagrant/environments/foreman/config.yaml
@@ -8,6 +8,7 @@ vm:
   puppet_agent: true           # Run puppet agent during provisioning
   facter_external_facts: true  # Create external facts in facts.d/$fact.txt. Note 1
   facter_trusted_facts: true   # Create csr_attributes.yaml. Note 1
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 # Note 1: Some facts are used in default hiera.yaml and needed for
 # nodes classification. So it's better to set them, once.

--- a/vagrant/environments/foss/config.yaml
+++ b/vagrant/environments/foss/config.yaml
@@ -8,6 +8,7 @@ vm:
   puppet_agent: true          # Run puppet agent during provisioning
   facter_external_facts: true # Create external facts in facts.d/$fact.txt. Note 1
   facter_trusted_facts: false # Create csr_attributes.yaml. Note 1
+  synced_folder_type: vboxfs  # Sync folders types: nfs, vboxfs
 
 # Note 1:   Some facts are used in default hiera.yaml and needed for
 # nodes classification. So it's better to set them, once.

--- a/vagrant/environments/lab/config.yaml
+++ b/vagrant/environments/lab/config.yaml
@@ -8,6 +8,7 @@ vm:
   puppet_agent: true           # Run puppet agent during provisioning
   facter_external_facts: true # Create external facts in facts.d/$fact.txt. Note 1
   facter_trusted_facts: true   # Create csr_attributes.yaml. Note 1
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 # Note 1: Some facts are used in default hiera.yaml and needed for
 # nodes classification. So it's better to set them, once.

--- a/vagrant/environments/ostest/config.yaml
+++ b/vagrant/environments/ostest/config.yaml
@@ -9,6 +9,7 @@ vm:
   puppet_agent: false          # Run puppet agent during provisioning
   facter_external_facts: true  # Create external facts in facts.d/$fact.txt. Note 1
   facter_trusted_facts: false  # Create csr_attributes.yaml. Note 1
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 # A local network is created among the VM. Here is configured.
 network:

--- a/vagrant/environments/pe/config.yaml
+++ b/vagrant/environments/pe/config.yaml
@@ -8,6 +8,7 @@ vm:
   puppet_agent: true           # Run puppet agent during provisioning
   facter_external_facts: false # Create external facts in facts.d/$fact.txt. Note 1
   facter_trusted_facts: true   # Create csr_attributes.yaml. Note 1
+  synced_folder_type: vboxfs   # Sync folders types: nfs, vboxfs
 
 # Note 1: Some facts are used in default hiera.yaml and needed for
 # nodes classification. So it's better to set them, once.


### PR DESCRIPTION
This change adds the option to choose which type of sync folders the user want to use. The allowed types are `vboxfs` (default for VirtualBox), `nfs`, `smb` and `rsync`. The default, in config.yaml, is `vboxfs`.

Fixes #256 .