### PR TITLE
Allow Puppet 5 FOSS installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 .onceover/
 .pe_build/
 /coverage/
-/bin/
 /doc/
 /Gemfile.local
 /Gemfile.lock

--- a/bin/bootstrap/puppet_foss.sh
+++ b/bin/bootstrap/puppet_foss.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [ -z $1 ]; then
+  echo 'No IP Address provided. Terminating.'
+  exit 1
+else
+  ip=$1
+fi
+hostname=$(hostname)
+
+vagrant/bin/vagrant-sethostname.sh $hostname
+vagrant/bin/vagrant-sethosts.sh $hostname $ip
+bin/puppet_set_external_facts.sh --role='puppet' --env 'host' --zone 'foss' --datacenter 'vagrant' --application 'puppetinfra'
+bin/puppet_set_trusted_facts.sh --role='puppet' --env 'host' --zone 'foss' --da
+tacenter 'vagrant' --application 'puppetinfra'
+vagrant/bin/puppet_install.sh '5'
+vagrant/bin/vagrant-setup_puppetserver.sh 'host'
+bin/puppet_deploy_controlrepo.sh
+

--- a/bin/puppet_install.sh
+++ b/bin/puppet_install.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
-breed=$1
+breed=$2
+if [ -z "$1" ]; then
+  puppet_version='6'
+else
+  if [ $1 == 'latest' ]; then
+    puppet_version='6'
+  else
+    puppet_version=$1
+  fi
+fi
 if [ $USER == 'root' ]; then
   sudo_command=''
 else
@@ -34,7 +43,7 @@ setup_redhat() {
   $sudo_command yum erase -y puppet-agent puppet puppetlabs-release puppetlabs-release-pc1 >/dev/null 2>&1
 
   echo_title "Adding repo for Puppet"
-  $sudo_command rpm -ivh https://yum.puppetlabs.com/puppet/puppet-release-el-$1.noarch.rpm >/dev/null 2>&1
+  $sudo_command rpm -ivh https://yum.puppetlabs.com/puppet$puppet_version-release-el-$1.noarch.rpm >/dev/null 2>&1
 
   sleep 2
   echo_title "Installing Puppet"
@@ -47,7 +56,7 @@ setup_fedora() {
   $sudo_command yum erase -y puppet-agent puppet puppetlabs-release puppetlabs-release-pc1 >/dev/null 2>&1
 
   echo_title "Adding repo for Puppet"
-  $sudo_command rpm -ivh https://yum.puppetlabs.com/puppet/puppet-release-fedora-${release}.noarch.rpm
+  $sudo_command rpm -ivh https://yum.puppetlabs.com/puppet$puppet_version-release-fedora-${release}.noarch.rpm
 
   sleep 2
   echo_title "Installing Puppet"
@@ -76,7 +85,7 @@ setup_suse() {
   $sudo_command zypper remove -y puppetlabs-release-pc1 >/dev/null 2>&1
 
   echo_title "Adding repo for Puppet"
-  $sudo_command wget https://yum.puppetlabs.com/puppet/puppet-release-sles-$1.noarch.rpm 2>&1
+  $sudo_command wget https://yum.puppetlabs.com/puppet$puppet_version-release-sles-$1.noarch.rpm 2>&1
   $sudo_command rpm -ivh puppet5-release-sles-$1.noarch.rpm 2>&1
 
   sleep 2
@@ -97,8 +106,8 @@ setup_apt() {
   esac
 
   echo_title "Adding repo for Puppet"
-  $sudo_command wget -q "http://apt.puppetlabs.com/puppet-release-${codename}.deb" >/dev/null
-  $sudo_command dpkg -i "puppet-release-${codename}.deb" >/dev/null
+  $sudo_command wget -q "http://apt.puppetlabs.com/puppet${puppet_version}-release-${codename}.deb" >/dev/null
+  $sudo_command dpkg -i "puppet${puppet_version}-release-${codename}.deb" >/dev/null
 
   echo_title "Running apt-get update"
   $sudo_command apt-get update >/dev/null 2>&1

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -119,6 +119,7 @@ Vagrant.configure('2') do |config|
     pe_role = node['pe_role'] if node['pe_role']
     pe_verbose = settings['puppet']['pe_verbose'] ? settings['puppet']['pe_verbose'] : true
     pe_version = settings['puppet']['pe_version']
+    version = settings['puppet']['version']
     pe_relocate_manifests = settings['puppet']['pe_relocate_manifests']
     pe_download_root = settings['puppet']['pe_download_root'] if settings['puppet']['pe_download_root']
     master_vm = settings['puppet']['master_vm'] if settings['puppet']['master_vm']
@@ -140,7 +141,7 @@ Vagrant.configure('2') do |config|
       node_config.vm.provision 'shell', path: '../../bin/vagrant-sethosts.sh', args: "#{puppet_master_hostname} #{puppet_master_ip}" if puppet_master_ip
       node_config.vm.provision 'shell', path: '../../../bin/puppet_set_external_facts.sh', args: "--role #{role} --env #{env} --zone #{zone} --datacenter #{datacenter} --application #{application}" if node['facter_external_facts']
       node_config.vm.provision 'shell', path: '../../../bin/puppet_set_trusted_facts.sh', args: "--role #{role} --env #{env} --zone #{zone} --datacenter #{datacenter} --application #{application}" if node['facter_trusted_facts']
-      node_config.vm.provision 'shell', path: '../../../bin/puppet_install.sh' if install_oss
+      node_config.vm.provision 'shell', path: '../../../bin/puppet_install.sh', args: "#{version}" if install_oss
 
       if Vagrant.has_plugin?('vagrant-hostmanager')
         node_config.hostmanager.aliases = aliases

--- a/vagrant/bin/vagrant-setup_puppetserver.sh
+++ b/vagrant/bin/vagrant-setup_puppetserver.sh
@@ -5,6 +5,7 @@ puppetserver_lock_file='/var/tmp/vagrant-setup_puppetserver.lock'
 setup_puppetserver() {
   echo "### Installing git"
   puppet resource package git ensure=present
+  puppet resource package puppetserver ensure=present
   which puppetserver 2>/dev/null
   if [ "x$?" == "x0" ]; then
     echo "### Installing gems for puppetserver"

--- a/vagrant/environments/foss/config.yaml
+++ b/vagrant/environments/foss/config.yaml
@@ -22,7 +22,7 @@ network:
 
 # Puppet related settings
 puppet:
-  version: latest                     # Version to use for OSS
+  version: '5'                     # Version to use for OSS
   install_oss: true                   # If to install Puppet OSS agent on the VMS
   install_pe: false                   # If to install Puppet Enterprise agent on the VMS
   env: devel                          # Setting for the env fact (may be used in hiera.yaml)


### PR DESCRIPTION
- config.yaml can specify puppet version 5,6 or 'latest'
- Vagrantfile uses puppet version config setting
- puppet install script now fetches apt and yum repo packages according
to parameter
- setup puppetserver was missing installation of puppetserver package