### PR TITLE
Add parameter for control repo to terraform

### DIFF
--- a/bin/bootstrap/cloud_gitlab_init.sh
+++ b/bin/bootstrap/cloud_gitlab_init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "10.0.1.1 puppet\n10.0.1.2 gitlab\n" >> /etc/hosts
 puppet_version=$1
 control_repo=$2
 yum install -y git

--- a/bin/bootstrap/cloud_gitlab_init.sh
+++ b/bin/bootstrap/cloud_gitlab_init.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 puppet_version=$1
+control_repo=$2
 yum install -y git
-git clone https://github.com/example42/psick /tmp/psick
+git clone $control_repo /tmp/psick
 pushd /tmp/psick
 bin/bootstrap/gitlab.sh $puppet_version
 popd

--- a/bin/bootstrap/cloud_master_init.sh
+++ b/bin/bootstrap/cloud_master_init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "10.0.1.1 puppet\n10.0.1.2 gitlab\n" >> /etc/hosts
 puppet_version=$1
 control_repo=$2
 yum install -y git

--- a/bin/bootstrap/cloud_master_init.sh
+++ b/bin/bootstrap/cloud_master_init.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 puppet_version=$1
+control_repo=$2
 yum install -y git
-git clone https://github.com/example42/psick /tmp/psick
+git clone $control_repo /tmp/psick
 pushd /tmp/psick
-bin/bootstrap/puppet_foss.sh $puppet_version
+bin/bootstrap/puppet_foss.sh $puppet_version $control_repo
 popd
 

--- a/bin/bootstrap/cloud_student_init.sh
+++ b/bin/bootstrap/cloud_student_init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "10.0.1.1 puppet\n10.0.1.2 gitlab\n" >> /etc/hosts
 puppet_version=$1
 control_repo=$2
 yum install -y git

--- a/bin/bootstrap/cloud_student_init.sh
+++ b/bin/bootstrap/cloud_student_init.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 puppet_version=$1
+control_repo=$2
 yum install -y git
-git clone https://github.com/example42/psick /tmp/psick
+git clone $control_repo /tmp/psick
 pushd /tmp/psick
 bin/bootstrap/student.sh $puppet_version
 popd

--- a/bin/bootstrap/puppet_foss.sh
+++ b/bin/bootstrap/puppet_foss.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 puppet_version=$1
+control_repo=$2
 echo "Set external facts"
 bin/puppet_set_external_facts.sh --role='puppet' --env 'host' --zone 'foss' --datacenter 'vagrant' --application 'puppetinfra'
 echo "Set trusted facts"
@@ -9,7 +10,7 @@ bin/puppet_install.sh $puppet_version
 echo "Deploy Puppet Master"
 vagrant/bin/vagrant-setup_puppetserver.sh 'host'
 echo "Deploy control-repository"
-bin/puppet_deploy_controlrepo.sh
+bin/puppet_deploy_controlrepo.sh $control_repo
 echo "Starting Puppet Server"
 /opt/puppetlabs/bin/puppet resource service puppetserver ensure=running enable=true
 

--- a/terraform/hcloud.tf
+++ b/terraform/hcloud.tf
@@ -36,6 +36,28 @@ variable "puppet_version" {
   }
 }
 
+variable "hcloud_students" {
+  type = map
+  description = "Hash of IPs to use for student maschines."
+  default = {
+    "stud1" = "10.0.1.11",
+    "stud2" = "10.0.1.12",
+    "stud3" = "10.0.1.13",
+    "stud4" = "10.0.1.14",
+    "stud5" = "10.0.1.15",
+    "stud6" = "10.0.1.16",
+    "stud7" = "10.0.1.17",
+    "stud8" = "10.0.1.18",
+    "stud9" = "10.0.1.19",
+    "stud10" = "10.0.1.20",
+    "stud11" = "10.0.1.21",
+    "stud12" = "10.0.1.22",
+    "stud13" = "10.0.1.23",
+    "stud14" = "10.0.1.24",
+    "stud15" = "10.0.1.25",
+  }
+}
+
 # Configure the Hetzner Cloud Provider
 provider "hcloud" {
   token   = var.hcloud_token
@@ -44,6 +66,7 @@ provider "hcloud" {
 
 data "hcloud_ssh_keys" "all_keys" {
 }
+
 
 resource "hcloud_network" "workshop" {
   name = "workshop"
@@ -73,7 +96,7 @@ resource "hcloud_server_network" "client_nodes" {
   for_each   = hcloud_server.client_nodes
   server_id  = hcloud_server.client_nodes[each.key].id
   network_id = hcloud_network.workshop.id
-  ip = "10.0.1.1[hcloud_server.client_nodes.each.id]"
+  ip = var.hcloud_students[hcloud_server.client_nodes[each.key].name]
 }
 
 resource "hcloud_server" "puppet" {

--- a/terraform/hcloud.tf
+++ b/terraform/hcloud.tf
@@ -67,6 +67,9 @@ provider "hcloud" {
 data "hcloud_ssh_keys" "all_keys" {
 }
 
+data "hcloud_ssh_keys" "admin_keys" {
+  with_selector = "role=admin"
+}
 
 resource "hcloud_network" "workshop" {
   name = "workshop"
@@ -103,7 +106,7 @@ resource "hcloud_server" "puppet" {
   name        = "puppet"
   image       = "centos-7"
   server_type = "cx41"
-  ssh_keys    = data.hcloud_ssh_keys.all_keys.ssh_keys.*.name
+  ssh_keys    = data.hcloud_ssh_keys.admin_keys.ssh_keys.*.name
   location    = "fsn1"
   labels      = { "use" = "schulung" }
   connection {
@@ -128,7 +131,7 @@ resource "hcloud_server" "gitlab" {
   name        = "gitlab"
   image       = "centos-7"
   server_type = "cx21"
-  ssh_keys    = data.hcloud_ssh_keys.all_keys.ssh_keys.*.name
+  ssh_keys    = data.hcloud_ssh_keys.admin_keys.ssh_keys.*.name
   location    = "fsn1"
   labels      = { "use" = "schulung" }
   connection {

--- a/terraform/hcloud.tf
+++ b/terraform/hcloud.tf
@@ -20,6 +20,12 @@ variable "sshkey" {
   description = "The full path to ssh key file for provisioning. May not have a passphrase and must be added to cloud provider prior usage, e.g. /home/user/.ssh/hetzner_private"
 }
 
+variable "control_repo" {
+  type = string
+  description = "The control-repo you want to use. Defaults to example42/psick."
+  default = "https://github.com/example42/psick.git"
+}
+
 variable "puppet_version" {
   type = number
   description = "The Puppet version to use. Specify 5 or 6"
@@ -59,7 +65,7 @@ resource "hcloud_server" "puppet" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/cloud_master_init.sh",
-      "/tmp/cloud_master_init.sh ${var.puppet_version}",
+      "/tmp/cloud_master_init.sh ${var.puppet_version} ${var.control_repo}",
     ]
   }
 }
@@ -84,7 +90,7 @@ resource "hcloud_server" "gitlab" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/cloud_gitlab_init.sh",
-      "/tmp/cloud_gitlab_init.sh ${var.puppet_version}",
+      "/tmp/cloud_gitlab_init.sh ${var.puppet_version} ${var.control_repo}",
     ]
   }
 }
@@ -110,7 +116,7 @@ resource "hcloud_server" "client_nodes" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/cloud_student_init.sh",
-      "/tmp/cloud_student_init.sh ${var.puppet_version}",
+      "/tmp/cloud_student_init.sh ${var.puppet_version} ${var.control_repo}",
     ]
   }
 }

--- a/terraform/hcloud.tf
+++ b/terraform/hcloud.tf
@@ -45,6 +45,37 @@ provider "hcloud" {
 data "hcloud_ssh_keys" "all_keys" {
 }
 
+resource "hcloud_network" "workshop" {
+  name = "workshop"
+  ip_range = "10.0.0.0/8"
+}
+
+resource "hcloud_network_subnet" "workshop_subnet" {
+  network_id = hcloud_network.workshop.id
+  type = "server"
+  network_zone = "eu-central"
+  ip_range   = "10.0.1.0/24"
+}
+
+resource "hcloud_server_network" "puppet" {
+  server_id = hcloud_server.puppet.id
+  network_id = hcloud_network.workshop.id
+  ip = "10.0.1.1"
+}
+
+resource "hcloud_server_network" "gitlab" {
+  server_id = hcloud_server.gitlab.id
+  network_id = hcloud_network.workshop.id
+  ip = "10.0.1.2"
+}
+
+resource "hcloud_server_network" "client_nodes" {
+  for_each   = hcloud_server.client_nodes
+  server_id  = hcloud_server.client_nodes[each.key].id
+  network_id = hcloud_network.workshop.id
+  ip = "10.0.1.1[hcloud_server.client_nodes.each.id]"
+}
+
 resource "hcloud_server" "puppet" {
   name        = "puppet"
   image       = "centos-7"


### PR DESCRIPTION
When spinning up cloud instances, we want to be able to specify workshop
individual control-repository.
Defaults to psick control-repo

