### PR TITLE
Add gitpod files for editing on gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,15 @@
+FROM gitpod/workspace-full
+RUN sudo wget https://apt.puppet.com/puppet-tools-release-bionic.deb && \
+  wget https://apt.puppetlabs.com/puppet6-release-bionic.deb && \
+  sudo dpkg -i puppet6-release-bionic.deb && \
+  sudo dpkg -i puppet-tools-release-bionic.deb && \
+  sudo apt-get update && sudo apt-get install -y pdk zsh puppet-agent
+RUN sudo usermod -s $(which zsh) gitpod && \
+  sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" && \
+  echo "plugins=(git gitignore github gem pip bundler python ruby docker docker-compose)" >> /home/gitpod/.zshrc && \
+  echo 'PATH="$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin"'  >> /home/gitpod/.zshrc && \
+  sudo /opt/puppetlabs/puppet/bin/gem install puppet-debugger hub -N && \
+  mkdir -p /home/gitpod/.config/puppet && \
+  /opt/puppetlabs/puppet/bin/ruby -r yaml -e "puts ({'disabled' => true}).to_yaml" > /home/gitpod/.config/puppet/analytics.yml
+RUN rm -f puppet6-release-bionic.deb  puppet-tools-release-bionic.deb
+ENTRYPOINT /usr/bin/zsh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: pdk bundle install
+
+vscode:
+  extensions:
+    - puppet.puppet-vscode@0.28.0:g5CT+jlJywUtP9HoX4DIZg==

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/example42/psick)
+
 <img align="right" src="html/images/PSICK-logo-200x200.png" />
 
 # PSICK


### PR DESCRIPTION
This PR adds gitpod cloud dev environment support.

An example of this can be found here

[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/nwops/psick)

