### PR TITLE
fix_vagrant_synced_folders_bug

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -150,6 +150,7 @@ Vagrant.configure('2') do |config|
 
       if Vagrant.has_plugin?('vagrant-vbguest')
         node_config.vbguest.installer_options = { allow_kernel_upgrade: true } if vm_box.start_with?('centos')
+        node_config.vm.synced_folder "./", "/vagrant", type: "virtualbox"
       end  
 
       if Vagrant.has_plugin?('vagrant-pe_build') && pe_role == 'master'


### PR DESCRIPTION
- /vagrant is on centos somehow "rsynced", so pe_build is not found immediately
- "rsync" is only executed once on up and reload at the start of the vm
- explicitly make /vagrant a mount in Vagrantfile
- pe_build is now found instantly and one run is enough to setup the master
- fixing the bug from "Note 1"
